### PR TITLE
Check credo config for large_number rewrite

### DIFF
--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -14,6 +14,7 @@ defmodule Quokka.Config do
 
   alias Credo.Check.Readability.AliasOrder
   alias Credo.Check.Readability.BlockPipe
+  alias Credo.Check.Readability.LargeNumbers
   alias Credo.Check.Readability.MaxLineLength
   alias Credo.Check.Readability.ParenthesesOnZeroArityDefs
   alias Credo.Check.Readability.SinglePipe
@@ -73,6 +74,7 @@ defmodule Quokka.Config do
     :persistent_term.put(@key, %{
       block_pipe_flag: credo_opts[:block_pipe_flag] || false,
       block_pipe_exclude: credo_opts[:block_pipe_exclude] || [],
+      large_numbers_gt: credo_opts[:large_numbers_gt] || :infinity,
       lifting_excludes: excludes,
       line_length: credo_opts[:line_length] || 98,
       pipe_chain_start_flag: credo_opts[:pipe_chain_start_flag] || false,
@@ -116,6 +118,10 @@ defmodule Quokka.Config do
     get(:block_pipe_exclude)
   end
 
+  def large_numbers_gt() do
+    get(:large_numbers_gt)
+  end
+
   def line_length() do
     get(:line_length)
   end
@@ -156,6 +162,10 @@ defmodule Quokka.Config do
         acc
         |> Map.put(:block_pipe_flag, true)
         |> Map.put(:block_pipe_exclude, opts[:exclude])
+
+      {LargeNumbers, opts}, acc when is_list(opts) ->
+        acc
+        |> Map.put(:large_numbers_gt, opts[:only_greater_than] || 9999)
 
       {MaxLineLength, opts}, acc when is_list(opts) ->
         Map.put(acc, :line_length, opts[:max_length])

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -351,6 +351,21 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("0b1111_1111_1111_1111")
       assert_style("0o777_7777")
     end
+
+    test "respects credo config :only_greater_than" do
+      Quokka.Config.set_for_test!(:large_numbers_gt, 20_000)
+      assert_style("20000", "20000")
+      assert_style("20001", "20_001")
+      Quokka.Config.set_for_test!(:large_numbers_gt, 9999)
+      assert_style("20000", "20_000")
+    end
+
+    test "respects credo config LargeNumbers false" do
+      Quokka.Config.set_for_test!(:large_numbers_gt, :infinity)
+      assert_style("10000", "10000")
+      Quokka.Config.set_for_test!(:large_numbers_gt, 9999)
+      assert_style("10000", "10_000")
+    end
   end
 
   describe "Enum.into and $collectable.new" do


### PR DESCRIPTION
If the LargeNumber check is not specified, no number will be rewritten. If it is specified but doesn't have a minimum set, we will match the default credo minimum of 10_000. If there is a minimum set, we will use that.