### PR TITLE
Change default behavior for zero arity parens

### DIFF
--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -75,7 +75,7 @@ defmodule Quokka.Config do
       rewrite_multi_alias: credo_opts[:rewrite_multi_alias] || false,
       single_pipe_flag: credo_opts[:single_pipe_flag] || false,
       sort_order: credo_opts[:sort_order] || :alpha,
-      zero_arity_parens: credo_opts[:zero_arity_parens] || true
+      zero_arity_parens: credo_opts[:zero_arity_parens]
     })
   end
 
@@ -198,7 +198,7 @@ defmodule Quokka.Config do
         Map.put(acc, :rewrite_multi_alias, true)
 
       {ParenthesesOnZeroArityDefs, opts}, acc when is_list(opts) ->
-        Map.put(acc, :zero_arity_parens, opts[:parens])
+        Map.put(acc, :zero_arity_parens, opts[:parens] || false)
 
       {PipeChainStart, opts}, acc when is_list(opts) ->
         acc

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -172,14 +172,14 @@ defmodule Quokka.Style.SingleNode do
 
   # Remove parens from 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
   defp style({def, dm, [{fun, funm, []} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
-    if Quokka.Config.zero_arity_parens?(),
-      do: node,
-      else: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]})
+    if Quokka.Config.zero_arity_parens?() == false,
+      do: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]}),
+      else: node
   end
 
   # Add parens to 0 arity funs (Credo.Check.Readability.ParenthesesOnZeroArityDefs)
   defp style({def, dm, [{fun, funm, nil} | rest]} = node) when def in ~w(def defp)a and is_atom(fun) do
-    if Quokka.Config.zero_arity_parens?(),
+    if Quokka.Config.zero_arity_parens?() == true,
       do: {def, dm, [{fun, Keyword.put(funm, :closing, line: funm[:line]), []} | rest]},
       else: node
   end

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -12,6 +12,10 @@
 defmodule Quokka.Style.BlocksTest do
   use Quokka.StyleCase, async: true
 
+  setup do
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
+  end
+
   describe "with statements" do
     test "replacement due to no (or all removed) arrows" do
       assert_style(

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -12,6 +12,10 @@
 defmodule Quokka.Style.DefsTest do
   use Quokka.StyleCase, async: true
 
+  setup do
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
+  end
+
   describe "run" do
     test "comments stay put when we can't shrink the head, even with blocks" do
       assert_style("""

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -17,6 +17,7 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
     Quokka.Config.set_for_test!(:lift_alias, true)
     Quokka.Config.set_for_test!(:lift_alias_depth, 2)
     Quokka.Config.set_for_test!(:lift_alias_frequency, 1)
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
 
     on_exit(fn ->
       Quokka.Config.set!([])

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -15,6 +15,7 @@ defmodule Quokka.Style.ModuleDirectivesTest do
 
   setup_all do
     Quokka.Config.set_for_test!(:rewrite_multi_alias, true)
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
     on_exit(fn ->
       Quokka.Config.set_for_test!(:rewrite_multi_alias, false)
     end)

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -12,6 +12,10 @@
 defmodule Quokka.Style.SingleNodeTest do
   use Quokka.StyleCase, async: true
 
+  setup do
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
+  end
+
   test "string sigil rewrites" do
     assert_style ~s|""|
     assert_style ~s|"\\""|
@@ -174,8 +178,6 @@ defmodule Quokka.Style.SingleNodeTest do
 
       # Regression: be wary of invocations with extra parens from metaprogramming
       assert_style("def metaprogramming(foo)(), do: bar")
-
-      Quokka.Config.set_for_test!(:zero_arity_parens, true)
     end
 
     test "prefers implicit try" do

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -14,6 +14,9 @@ defmodule Quokka.Style.StylesTest do
   A place for tests that make sure our styles play nicely with each other
   """
   use Quokka.StyleCase, async: true
+  setup do
+    Quokka.Config.set_for_test!(:zero_arity_parens, true)
+  end
 
   describe "pipes + defs" do
     test "pipes doesnt abuse meta and break defs" do


### PR DESCRIPTION
Previously, the default behavior was to add parenthesis to all 0-arity functions unless configured otherwise by credo. The correct default should be to do nothing if the check is not specified in credo. If the check is specified, we should use the true/false setting from credo and use false as the default when the boolean is not explicitly stated in order to match credo.