### PR TITLE
Make tests sync to eliminate flakiness

### DIFF
--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -10,7 +10,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Quokka.Style.BlocksTest do
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup do
     Quokka.Config.set_for_test!(:zero_arity_parens, true)

--- a/test/style/configs_test.exs
+++ b/test/style/configs_test.exs
@@ -11,7 +11,7 @@
 
 defmodule Quokka.Style.ConfigsTest do
   @moduledoc false
-  use Quokka.StyleCase, async: true, filename: "config/config.exs"
+  use Quokka.StyleCase, async: false, filename: "config/config.exs"
 
   alias Quokka.Style.Configs
 

--- a/test/style/defs_test.exs
+++ b/test/style/defs_test.exs
@@ -10,7 +10,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Quokka.Style.DefsTest do
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup do
     Quokka.Config.set_for_test!(:zero_arity_parens, true)

--- a/test/style/deprecations_test.exs
+++ b/test/style/deprecations_test.exs
@@ -10,7 +10,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Quokka.Style.DeprecationsTest do
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   test "Logger.warn to Logger.warning" do
     assert_style("Logger.warn(foo)", "Logger.warning(foo)")

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -11,7 +11,7 @@
 
 defmodule Quokka.Style.ModuleDirectivesTest do
   @moduledoc false
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup_all do
     Quokka.Config.set_for_test!(:rewrite_multi_alias, true)

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -10,7 +10,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Quokka.Style.PipesTest do
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup do
     Quokka.Config.set_for_test!(:single_pipe_flag, true)

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -10,7 +10,7 @@
 # governing permissions and limitations under the License.
 
 defmodule Quokka.Style.SingleNodeTest do
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup do
     Quokka.Config.set_for_test!(:zero_arity_parens, true)

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -13,7 +13,7 @@ defmodule Quokka.Style.StylesTest do
   @moduledoc """
   A place for tests that make sure our styles play nicely with each other
   """
-  use Quokka.StyleCase, async: true
+  use Quokka.StyleCase, async: false
 
   setup do
     Quokka.Config.set_for_test!(:zero_arity_parens, true)

--- a/test/style_test.exs
+++ b/test/style_test.exs
@@ -1,5 +1,5 @@
 defmodule Quokka.StyleTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Quokka.Style, only: [displace_comments: 2, shift_comments: 3]
 

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -12,7 +12,7 @@
 # Branched from https://github.com/doorgan/sourceror/blob/main/test/zipper_test.exs
 # See this issue for context on branching: https://github.com/doorgan/sourceror/issues/67
 defmodule QuokkaTest.ZipperTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Quokka.Zipper
 


### PR DESCRIPTION
This is not the best solution ever, but it's the fastest fix to eliminate flakiness. Tests don't take long even with all being synchronous. If we get to a point where tests are taking a long time, we can consider a different approach.

closes #24 