### PR TITLE
feat: respect .formatter.exs line_length

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,5 +8,5 @@
     assert_style: 2
   ],
   plugins: [Quokka],
-  line_length: 122
+  line_length: 98
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,5 +8,5 @@
     assert_style: 2
   ],
   plugins: [Quokka],
-  line_length: 98
+  line_length: 120
 ]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add `:quokka` as a dependency to your project's `mix.exs`:
 ```elixir
 def deps do
   [
-    {:quokka, "~> 0.1", only: [:dev, :test], runtime: false},
+    {:quokka, "~> 2.1", only: [:dev, :test], runtime: false},
   ]
 end
 ```

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -388,7 +388,7 @@ end
 
 ## Line Length
 
-This addresses [`Credo.Check.Readability.MaxLineLength`](https://hexdocs.pm/credo/Credo.Check.Readability.MaxLineLength.html). Quokka will respect the `:line_length` configuration (from `.credo.exs`) when determining whether to split lines. When possible, will compress code onto a single line if it fits within the configured length.
+This addresses [`Credo.Check.Readability.MaxLineLength`](https://hexdocs.pm/credo/Credo.Check.Readability.MaxLineLength.html). Quokka will respect the `:line_length` configuration (from `.credo.exs`, `.formatter.exs`) when determining whether to split lines. When possible, will compress code onto a single line if it fits within the configured length.
 
 ```elixir
 # Before - Multiple lines when it could fit on one

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -388,7 +388,7 @@ end
 
 ## Line Length
 
-This addresses [`Credo.Check.Readability.MaxLineLength`](https://hexdocs.pm/credo/Credo.Check.Readability.MaxLineLength.html). Quokka will respect the `:line_length` configuration (from `.credo.exs`, `.formatter.exs`) when determining whether to split lines. When possible, will compress code onto a single line if it fits within the configured length.
+This addresses [`Credo.Check.Readability.MaxLineLength`](https://hexdocs.pm/credo/Credo.Check.Readability.MaxLineLength.html). Quokka will respect the `:line_length` configuration (from `.credo.exs`, `.formatter.exs`) prioritizing minimal `line_length` value when determining whether to split lines. When possible, will compress code onto a single line if it fits within the configured length.
 
 ```elixir
 # Before - Multiple lines when it could fit on one

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -89,7 +89,7 @@ defmodule Quokka.Config do
         lift_alias_excluded_lastnames: MapSet.new(lift_alias_excluded_lastnames ++ @stdlib),
         lift_alias_excluded_namespaces: MapSet.new(lift_alias_excluded_namespaces ++ @stdlib),
         lift_alias_frequency: credo_opts[:lift_alias_frequency] || 0,
-        line_length: credo_opts[:line_length] || formatter_opts[:line_length] || 98,
+        line_length: min(credo_opts[:line_length], formatter_opts[:line_length]) || 98,
         only_styles: quokka_config[:only] || [],
         pipe_chain_start_excluded_argument_types: credo_opts[:pipe_chain_start_excluded_argument_types] || [],
         pipe_chain_start_excluded_functions: credo_opts[:pipe_chain_start_excluded_functions] || [],

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -52,14 +52,15 @@ defmodule Quokka.Config do
     Range Record Regex Registry Set Stream String StringIO Supervisor System Task Time Tuple URI Version
   )a
 
-  def set(config) do
+  def set(formatter_opts) do
     :persistent_term.get(@key)
     :ok
   rescue
-    ArgumentError -> set!(config)
+    ArgumentError -> set!(formatter_opts)
   end
 
-  def set!(config \\ []) do
+  def set!(formatter_opts) do
+    quokka_config = formatter_opts[:quokka] || []
     credo_opts = extract_configs_from_credo()
 
     lift_alias_excluded_namespaces =
@@ -75,25 +76,25 @@ defmodule Quokka.Config do
       @key,
       # quokka:sort
       %{
-        autosort: config[:autosort] || [],
+        autosort: quokka_config[:autosort] || [],
         block_pipe_exclude: credo_opts[:block_pipe_exclude] || [],
         block_pipe_flag: credo_opts[:block_pipe_flag] || false,
-        directories_excluded: Map.get(config[:files] || %{}, :excluded, []),
-        directories_included: Map.get(config[:files] || %{}, :included, []),
-        exclude_styles: config[:exclude] || [],
-        inefficient_function_rewrites: Keyword.get(config, :inefficient_function_rewrites, true),
+        directories_excluded: Map.get(quokka_config[:files] || %{}, :excluded, []),
+        directories_included: Map.get(quokka_config[:files] || %{}, :included, []),
+        exclude_styles: quokka_config[:exclude] || [],
+        inefficient_function_rewrites: Keyword.get(quokka_config, :inefficient_function_rewrites, true),
         large_numbers_gt: credo_opts[:large_numbers_gt] || :infinity,
         lift_alias: credo_opts[:lift_alias] || false,
         lift_alias_depth: credo_opts[:lift_alias_depth] || 0,
         lift_alias_excluded_lastnames: MapSet.new(lift_alias_excluded_lastnames ++ @stdlib),
         lift_alias_excluded_namespaces: MapSet.new(lift_alias_excluded_namespaces ++ @stdlib),
         lift_alias_frequency: credo_opts[:lift_alias_frequency] || 0,
-        line_length: credo_opts[:line_length] || 98,
-        only_styles: config[:only] || [],
+        line_length: credo_opts[:line_length] || formatter_opts[:line_length] || 98,
+        only_styles: quokka_config[:only] || [],
         pipe_chain_start_excluded_argument_types: credo_opts[:pipe_chain_start_excluded_argument_types] || [],
         pipe_chain_start_excluded_functions: credo_opts[:pipe_chain_start_excluded_functions] || [],
         pipe_chain_start_flag: credo_opts[:pipe_chain_start_flag] || false,
-        piped_function_exclusions: config[:piped_function_exclusions] || [],
+        piped_function_exclusions: quokka_config[:piped_function_exclusions] || [],
         rewrite_multi_alias: credo_opts[:rewrite_multi_alias] || false,
         single_pipe_flag: credo_opts[:single_pipe_flag] || false,
         sort_order: credo_opts[:sort_order] || :alpha,

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -69,7 +69,7 @@ defmodule Quokka do
     file = formatter_opts[:file]
     styler_opts = formatter_opts[:quokka] || []
 
-    Quokka.Config.set(styler_opts)
+    Quokka.Config.set(formatter_opts)
 
     if Quokka.Config.allowed_directory?(file) do
       {ast, comments} =

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -11,12 +11,12 @@ defmodule Quokka.ConfigTest do
   end
 
   test "respects the `:only` configuration" do
-    assert :ok = set!(only: [:deprecations])
+    assert :ok = set!(quokka: [only: [:deprecations]])
     assert [Deprecations] == Quokka.Config.get_styles()
   end
 
   test "respects the `:exclude` configuration" do
-    assert :ok = set!(exclude: [:deprecations])
+    assert :ok = set!(quokka: [exclude: [:deprecations]])
 
     # Check for one of the default configs
     assert Configs in Quokka.Config.get_styles()
@@ -26,13 +26,18 @@ defmodule Quokka.ConfigTest do
   end
 
   test "respects the `:only` and `:exclude` configuration" do
-    assert :ok = set!(only: [:configs, :deprecations], exclude: [:deprecations])
+    assert :ok = set!(quokka: [only: [:configs, :deprecations], exclude: [:deprecations]])
 
     assert [Configs] == Quokka.Config.get_styles()
   end
 
   test "only applies line-length changes if :line_length is present in the `:only` configuration" do
-    assert :ok = set!(only: [:line_length])
+    assert :ok = set!(quokka: [only: [:line_length]])
     assert [] == Quokka.Config.get_styles()
+  end
+
+  test "respects the formatter_opts line_length configuration" do
+    assert :ok = set!(line_length: 999)
+    assert Quokka.Config.get(:line_length) == 999
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,6 +10,7 @@
 # governing permissions and limitations under the License.
 
 Mimic.copy(Quokka.Config)
+Mimic.copy(Credo.ConfigFile)
 Quokka.Config.set([])
 
 ExUnit.start(capture_log: true, formatters: [JUnitFormatter, ExUnit.CLIFormatter])


### PR DESCRIPTION
There are 2 ideas of how this could be implemented:
1. Pass formatter opts to Quokka.Config.set/1 (how I did in this PR)
2. Add formatter_opts as a key to styler_opts (example below)

Closes https://github.com/smartrent/quokka/issues/46

```elixir
# lib/styler.ex
styler_opts = [{:__formatter_opts__, formatter_opts} | styler_opts]

Quokka.Config.set(styler_opts)
```

```elixir
# lib/quokka/config.ex
def set!(config \\ []) do
  ...
  %{
    ...,
    line_length: credo_opts[:line_length] || config[:__formatter_opts__][:line_length] || 98
  }
end
```

Comment out which one you like more