### PR TITLE
Don't lift aliases from use or import unless already lifted

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -438,6 +438,9 @@ defmodule Quokka.Style.ModuleDirectives do
           {:skip, zipper, lifts}
         end
 
+      {{directive, _, _}, _} = zipper, lifts when directive in [:use, :import] ->
+        {:cont, zipper |> Zipper.down() |> Zipper.rightmost(), lifts}
+
       zipper, lifts ->
         {:cont, zipper, lifts}
     end)

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -850,7 +850,7 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
     end
   end
 
-  describe "alias lifting within use" do
+  describe "alias lifting within directives" do
     test "lifts aliases when use is after alias" do
       stub(Quokka.Config, :strict_module_layout_order, fn -> [:alias, :use] end)
       stub(Quokka.Config, :lift_alias_frequency, fn -> 0 end)
@@ -911,6 +911,62 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
       )
     end
 
+    test "doesn't lift `use` itself unless it will be lifted anyways" do
+      stub(Quokka.Config, :strict_module_layout_order, fn -> [:alias, :use] end)
+      stub(Quokka.Config, :lift_alias_frequency, fn -> 0 end)
+
+      assert_style(
+        """
+        defmodule MyApp.Schemas.MySchema do
+          use A.B.C,
+            derive: [
+              :id,
+              name: &MyApp.Schemas.MySchema.encode_name/1
+            ]
+        end
+        """,
+        """
+        defmodule MyApp.Schemas.MySchema do
+          alias MyApp.Schemas.MySchema
+
+          use A.B.C,
+            derive: [
+              :id,
+              name: &MySchema.encode_name/1
+            ]
+        end
+        """
+      )
+
+      assert_style(
+        """
+        defmodule MyApp.Schemas.MySchema do
+          use A.B.C,
+            derive: [
+              :id,
+              name: &MyApp.Schemas.MySchema.encode_name/1
+            ]
+
+          A.B.C.foo()
+        end
+        """,
+        """
+        defmodule MyApp.Schemas.MySchema do
+          alias A.B.C
+          alias MyApp.Schemas.MySchema
+
+          use C,
+            derive: [
+              :id,
+              name: &MySchema.encode_name/1
+            ]
+
+          C.foo()
+        end
+        """
+      )
+    end
+
     test "doesn't sort use" do
       stub(Quokka.Config, :strict_module_layout_order, fn -> [:alias, :use] end)
       stub(Quokka.Config, :lift_alias_frequency, fn -> 0 end)
@@ -941,6 +997,35 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
             ]
 
           use IDependOnTheOtherUseBeingFirst
+        end
+        """
+      )
+    end
+
+    test "doesn't lift `import` itself unless it will be lifted anyways" do
+      stub(Quokka.Config, :strict_module_layout_order, fn -> [:alias, :import] end)
+      stub(Quokka.Config, :lift_alias_frequency, fn -> 0 end)
+
+      assert_style("""
+      defmodule MyApp.Schemas.MySchema do
+        import A.B.C
+      end
+      """)
+
+      assert_style(
+        """
+        defmodule MyApp.Schemas.MySchema do
+          import A.B.C
+          A.B.C.foo()
+        end
+        """,
+        """
+        defmodule MyApp.Schemas.MySchema do
+          alias A.B.C
+
+          import C
+
+          C.foo()
         end
         """
       )


### PR DESCRIPTION
Quokka was lifting statements from `use` and `import`, which doesn't match Credo's behavior. This can get annoying, so let's change that behavior.

I also realize we could theoretically run into a problem if we have code like this:
```
use C
A.B.C.foo()
```
would become
```
alias A.B.C
use C
```
I can preemptively fix this, but I think it's so unlikely to happen, so I'll kick the can down the road.