### PR TITLE
[Fix] Ensure Alias excluded namespaces works properly

### DIFF
--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -48,7 +48,7 @@ defmodule Quokka.Config do
   @stdlib ~w(
     Access Agent Application Atom Base Behaviour Bitwise Code Date DateTime Dict Ecto Enum Exception
     File Float GenEvent GenServer HashDict HashSet Integer IO Kernel Keyword List
-    Macro Map MapSet Module NaiveDateTime Node Oban OptionParser Path Port Process Protocol
+    Macro Map MapSet Mix Module NaiveDateTime Node Oban OptionParser Path Port Process Protocol
     Range Record Regex Registry Set Stream String StringIO Supervisor System Task Time Tuple URI Version
   )a
 
@@ -73,11 +73,9 @@ defmodule Quokka.Config do
     quokka_config = formatter_opts[:quokka] || []
     credo_opts = extract_configs_from_credo()
 
-    lift_alias_excluded_namespaces =
-      Enum.map(credo_opts[:lift_alias_excluded_namespaces] || [], &Atom.to_string/1)
+    lift_alias_excluded_namespaces = credo_opts[:lift_alias_excluded_namespaces] || []
 
-    lift_alias_excluded_lastnames =
-      Enum.map(credo_opts[:lift_alias_excluded_lastnames] || [], &Atom.to_string/1)
+    lift_alias_excluded_lastnames = credo_opts[:lift_alias_excluded_lastnames] || []
 
     default_order = [:shortdoc, :moduledoc, :behaviour, :use, :import, :alias, :require]
     strict_module_layout_order = credo_opts[:strict_module_layout_order] || default_order

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -395,11 +395,20 @@ defmodule Quokka.Style.ModuleDirectives do
       {{:__aliases__, _, [first, _ | _] = aliases}, _} = zipper, lifts ->
         if Enum.all?(aliases, &is_atom/1) do
           alias_string = Enum.join(aliases, ".")
-
           excluded_namespace? =
             Quokka.Config.lift_alias_excluded_namespaces()
             |> MapSet.filter(fn namespace ->
-              String.starts_with?(alias_string, Atom.to_string(namespace) <> ".")
+              str_namespace = Atom.to_string(namespace)
+              str_namespace_to_exclude =
+                case str_namespace do
+                  "Elixir." <> rest_namespace ->
+                    rest_namespace
+
+                  _ ->
+                    str_namespace
+                end
+
+              String.starts_with?(alias_string, str_namespace_to_exclude <> ".")
             end)
             |> MapSet.size() > 0
 

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -542,15 +542,18 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
     end
 
     test "collisions with configured regexes" do
-      stub(Quokka.Config, :lift_alias_excluded_namespaces, fn -> MapSet.new([:Name]) end)
+      # "Elixir." is automatically prepended to namespaces and such namespaces should still be excluded from lifting
+      stub(Quokka.Config, :lift_alias_excluded_namespaces, fn -> MapSet.new([Elixir.Name1, Name2]) end)
 
       assert_style(
         """
         defmodule MyModule do
           alias Foo.Bar
 
-          Name.Y.Z.bar()
-          Name.Y.Z.bar()
+          Name1.Y.Z.bar()
+          Name1.Y.Z.bar()
+          Name2.Y.Z.bar()
+          Name2.Y.Z.bar()
           A.B.C.foo()
           A.B.C.foo()
           A.B.C.D.foo()
@@ -563,8 +566,10 @@ defmodule Quokka.Style.ModuleDirectives.AliasLiftingTest do
           alias A.B.C.D
           alias Foo.Bar
 
-          Name.Y.Z.bar()
-          Name.Y.Z.bar()
+          Name1.Y.Z.bar()
+          Name1.Y.Z.bar()
+          Name2.Y.Z.bar()
+          Name2.Y.Z.bar()
           C.foo()
           C.foo()
           D.foo()


### PR DESCRIPTION
## Background

I was trying to make use of excluded_namespaces for Credo's AliasUsage rule, but it wasn't working. This PR fixes that.
There were two issues:

1. Type expectation mismatch

Initially, there was a bug in the expectations of the type of `lift_alias_excluded_namespaces`. Before this change, it was storing a mix of atoms (stdlib) and strings (user provided config of excluded_namespaces in Credo). However `find_liftable_aliases` made an assumption that all the namespaces were atoms. 
The fix here was to consistently ensure we're dealing with Atoms for `lift_alias_excluded_namespaces`.

2. Alias Lifting not working with namespaces due to "Elixir." prefix that is auto-prepended to modules.
The namespaces provided in the config will automatically have an "Elixir." namespace prefix prepended to them, so String.starts_with? operation wasn't working. 
We now account for this.

After these two fixes, I could confirm with the codebase I ran quokka on, that things were working as intended again.

Lastly, I also added `Mix` to stdlib to ensure we don't alias lift that.

## Changes
- Fix AliasUsage to properly respect `lift_alias_excluded_namespaces`
- Add `Mix` to stdlib module attribute to ensure we don't alias lift that.

## Testing

Manually tested that things now work with my codebase. The previous tests couldn't catch this issue since they were stubbing Quokka Config directly.

## Other Considerations

