### PR TITLE
[Fix] Fix pipe chain start with alias lifting exceptions

### DIFF
--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -443,7 +443,7 @@ defmodule Quokka.Style.Pipes do
   # 'char#{list} interpolation'
   defp valid_pipe_start?({{:., _, [List, :to_charlist]}, _, _}), do: true
   # n-arity Module.function_call(...args)
-  defp valid_pipe_start?({{:., _, [{_, _, mod_list}, fun]}, _, arguments}) do
+  defp valid_pipe_start?({{:., _, [{_, _, mod_list}, fun]}, _, arguments}) when is_list(mod_list) do
     not Quokka.Config.refactor_pipe_chain_starts?() or
       first_arg_excluded_type?(arguments) or
       "#{Enum.join(mod_list, ".")}.#{fun}" in Quokka.Config.pipe_chain_start_excluded_functions()

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -443,10 +443,10 @@ defmodule Quokka.Style.Pipes do
   # 'char#{list} interpolation'
   defp valid_pipe_start?({{:., _, [List, :to_charlist]}, _, _}), do: true
   # n-arity Module.function_call(...args)
-  defp valid_pipe_start?({{:., _, [{_, _, [mod]}, fun]}, _, arguments}) do
+  defp valid_pipe_start?({{:., _, [{_, _, mod_list}, fun]}, _, arguments}) do
     not Quokka.Config.refactor_pipe_chain_starts?() or
       first_arg_excluded_type?(arguments) or
-      "#{mod}.#{fun}" in Quokka.Config.pipe_chain_start_excluded_functions()
+      "#{Enum.join(mod_list, ".")}.#{fun}" in Quokka.Config.pipe_chain_start_excluded_functions()
   end
 
   # variable

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -51,6 +51,35 @@ defmodule Quokka.Style.PipesTest do
       )
     end
 
+    test "pipe chain start should work with excluded alias lifting namespaces" do
+      stub(Quokka.Config, :lift_alias_excluded_namespaces, fn -> MapSet.new([:Name]) end)
+
+      assert_style(
+        """
+        defmodule MyModule do
+          alias Foo.Bar
+
+          Name.M.N.bar(x)
+          |> Name.M.N.bar()
+
+          A.B.C.foo()
+        end
+        """,
+        """
+        defmodule MyModule do
+          alias A.B.C
+          alias Foo.Bar
+
+          x
+          |> Name.M.N.bar()
+          |> Name.M.N.bar()
+
+          C.foo()
+        end
+        """
+      )
+    end
+
     test "fixes nested pipes" do
       stub(Quokka.Config, :block_pipe_flag?, fn -> true end)
 


### PR DESCRIPTION
I've noticed that pipe chain start rule isn't respected for namespaces that are excluded from alias lifting rule:

For example:
stub(Quokka.Config, :lift_alias_excluded_namespaces, fn -> MapSet.new([:Name]) end)
```elixir
defmodule MyModule do
    alias Foo.Bar

     Name.M.N.bar(x)
      |> Name.M.N.bar()

     A.B.C.foo()
end
```

currently refactors to

```elixir
defmodule MyModule do
    alias A.B.C
    alias Foo.Bar

     Name.M.N.bar(x)
      |> Name.M.N.bar()

     C.foo()
end
```

and I was assuming it'd refactor to:

```elixir
defmodule MyModule do
    alias A.B.C
    alias Foo.Bar

     x
      |> Name.M.N.bar()
      |> Name.M.N.bar()

     C.foo()
end
```
I was imagining that the alias lifting excluded namespaces shouldn't fail and proposing an example fix

closes #68 