### PR TITLE
fix: don't crash on empty module

### DIFF
--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -22,6 +22,17 @@ defmodule Quokka do
 
   @doc false
   def style({ast, comments}, file, opts) do
+    # Don't style empty modules
+    case ast do
+      {:defmodule, _, [_, [{{:__block__, _, [:do]}, {:__block__, _, []}}]]} ->
+        {ast, comments}
+
+      _ ->
+        apply_styles({ast, comments}, file, opts)
+    end
+  end
+
+  defp apply_styles({ast, comments}, file, opts) do
     on_error = opts[:on_error] || :log
     zipper = Zipper.zip(ast)
 

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -16,6 +16,13 @@ defmodule Quokka.Style.StylesTest do
   use Quokka.StyleCase, async: true
   use Mimic
 
+  test "doesn't crash on defmodule with empty body" do
+    assert_style("""
+    defmodule Foo do
+    end
+    """)
+  end
+
   describe "pipes + defs" do
     test "pipes doesn't abuse meta and break defs" do
       stub(Quokka.Config, :zero_arity_parens?, fn -> true end)


### PR DESCRIPTION
closes #69 