### PR TITLE
Use mixfile to determine elixir version

### DIFF
--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -101,4 +101,56 @@ defmodule Quokka.ConfigTest do
     # check that stdlib is included in the exclusions
     MapSet.member?(Quokka.Config.lift_alias_excluded_namespaces(), "File")
   end
+
+  test "parses elixir version from mix.exs with different requirement formats" do
+    mix_exs_path = Path.join(File.cwd!(), "mix.exs")
+    original_content = File.read!(mix_exs_path)
+
+    test_cases = [
+      {~s(elixir: "~> 1"), "1.0.0"},
+      {~s(elixir: "~> 1.15"), "1.15.0"},
+      {~s(elixir: ">= 1.16.0"), "1.16.0"},
+      {~s(elixir: "== 1.17.0"), "1.17.0"},
+      {~s(elixir: "> 1.18.0"), "1.18.0"},
+      {~s(elixir: ">= 1.15.0 and < 2.0.0"), "1.15.0"},
+      {~s(elixir: ">= 1.15.0-dev"), "1.15.0-dev"}
+    ]
+
+    try do
+      Enum.each(test_cases, fn {requirement, expected} ->
+        File.write!(mix_exs_path, """
+        defmodule Test.MixProject do
+          use Mix.Project
+
+          def project do
+            [
+              app: :test,
+              version: "0.1.0",
+              #{requirement}
+            ]
+          end
+        end
+        """)
+
+        assert :ok = Quokka.Config.set!([])
+        assert expected == Quokka.Config.elixir_version()
+      end)
+    after
+      File.write!(mix_exs_path, original_content)
+    end
+  end
+
+  test "falls back to System.version() if mix.exs cannot be read" do
+    mix_exs_path = Path.join(File.cwd!(), "mix.exs")
+    original_content = File.read!(mix_exs_path)
+
+    try do
+      File.rm!(mix_exs_path)
+
+      assert :ok = Quokka.Config.set!([])
+      assert System.version() == Quokka.Config.elixir_version()
+    after
+      File.write!(mix_exs_path, original_content)
+    end
+  end
 end

--- a/test/style/deprecations_test.exs
+++ b/test/style/deprecations_test.exs
@@ -134,7 +134,10 @@ defmodule Quokka.Style.DeprecationsTest do
   end
 
   describe "1.16+" do
-    @describetag skip: Version.match?(System.version(), "< 1.16.0-dev")
+    setup do
+      Mimic.stub(Quokka.Config, :elixir_version, fn -> "1.16.0" end)
+      :ok
+    end
 
     test "File.stream!(path, modes, line_or_bytes) to File.stream!(path, line_or_bytes, modes)" do
       assert_style(
@@ -150,7 +153,10 @@ defmodule Quokka.Style.DeprecationsTest do
   end
 
   describe "1.17+" do
-    @describetag skip: Version.match?(System.version(), "< 1.17.0-dev")
+    setup do
+      Mimic.stub(Quokka.Config, :elixir_version, fn -> "1.17.0" end)
+      :ok
+    end
 
     test "to_timeout/1 vs :timer.units(x)" do
       assert_style ":timer.hours(x)", "to_timeout(hour: x)"


### PR DESCRIPTION
I have a global elixir version, but some repos have a different elixir version than that. Instead of checking the system version, we should get it from the mixfile.