### PR TITLE
Add config to ignore numbers with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ in `.formatter.exs` to fine tune your setup:
       | :module_directives
       | :pipes
       | :single_node
+      # Don't re-underscore large numbers with underscores. Ie, leave 100_00 as-is.
+      | :nums_with_underscores
     ],
     piped_function_exclusions: [:subquery, :"Repo.update", ...]
   ]

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -26,8 +26,7 @@ This addresses [`Credo.Check.Readability.LargeNumbers`](https://hexdocs.pm/credo
 Style base 10 numbers with 5 or more digits to have a `_` every three digits.
 Formatter already does this except it doesn't rewrite "typos" like `100_000_0`.
 
-If you're concerned that this breaks your team's formatting for things like "cents" (like "$100" being written as `100_00`),
-consider using a library made for denoting currencies rather than raw elixir integers.
+If you're concerned that this breaks your team's formatting for things like "cents" (like "$100" being written as `100_00`), add `:nums_with_underscores` to the `:exclude` config.
 
 | Before             | After                                                 |
 | ------------------ | ----------------------------------------------------- |

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -115,6 +115,7 @@ defmodule Quokka.Config do
           MapSet.new(Enum.map(lift_alias_excluded_namespaces, &String.to_atom/1) ++ @stdlib),
         lift_alias_frequency: credo_opts[:lift_alias_frequency] || 0,
         line_length: min(credo_opts[:line_length], formatter_opts[:line_length]) || 98,
+        nums_with_underscores: Keyword.get(quokka_config, :exclude, []) |> Enum.member?(:nums_with_underscores),
         only_styles: quokka_config[:only] || [],
         pipe_chain_start_excluded_argument_types: credo_opts[:pipe_chain_start_excluded_argument_types] || [],
         pipe_chain_start_excluded_functions: credo_opts[:pipe_chain_start_excluded_functions] || [],
@@ -215,6 +216,10 @@ defmodule Quokka.Config do
 
   def line_length() do
     get(:line_length)
+  end
+
+  def exclude_nums_with_underscores?() do
+    get(:nums_with_underscores)
   end
 
   def pipe_chain_start_excluded_functions() do

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -386,7 +386,13 @@ defmodule Quokka.Style.SingleNode do
     end)
   end
 
-  defp delimit(token), do: token |> String.to_charlist() |> remove_underscores([]) |> add_underscores([])
+  defp delimit(token) do
+    if Quokka.Config.exclude_nums_with_underscores?() and String.contains?(token, "_") do
+      token
+    else
+      token |> String.to_charlist() |> remove_underscores([]) |> add_underscores([])
+    end
+  end
 
   defp remove_underscores([?_ | rest], acc), do: remove_underscores(rest, acc)
   defp remove_underscores([digit | rest], acc), do: remove_underscores(rest, [digit | acc])

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -560,6 +560,16 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("0o777_7777")
     end
 
+    test "respects quokka config exclude: :nums_with_underscores" do
+      stub(Quokka.Config, :exclude_nums_with_underscores?, fn -> true end)
+      assert_style("100_00", "100_00")
+      assert_style("1_0_0_0_0", "1_0_0_0_0")
+
+      stub(Quokka.Config, :exclude_nums_with_underscores?, fn -> false end)
+      assert_style("100_00", "10_000")
+      assert_style("1_0_0_0_0", "10_000")
+    end
+
     test "respects credo config :only_greater_than" do
       stub(Quokka.Config, :large_numbers_gt, fn -> 20_000 end)
       assert_style("20000", "20000")


### PR DESCRIPTION
Sometimes there are good reasons to underscore numbers like `100_00` (for example, if this represents cents). Add a config to not re-delimit numbers with underscores.

Closes #82 