### PR TITLE
Sort numeric map keys naturally

### DIFF
--- a/lib/style/comment_directives.ex
+++ b/lib/style/comment_directives.ex
@@ -50,7 +50,7 @@ defmodule Quokka.Style.CommentDirectives do
       should_skip = node_line && MapSet.member?(skip_sort_lines, node_line)
       has_comments = has_comments_inside?(node, ctx.comments)
       is_sortable = get_node_type(node) in autosort_types
-      is_query = is_ecto_from_query?(node)
+      is_query = ecto_from_query?(node)
 
       cond do
         is_query and Quokka.Config.autosort_exclude_ecto?() ->
@@ -66,7 +66,7 @@ defmodule Quokka.Style.CommentDirectives do
     end
   end
 
-  defp is_ecto_from_query?(node) do
+  defp ecto_from_query?(node) do
     case node do
       # Matches the remote call: `Ecto.Query.from(...)`
       {{:., _, [{:__aliases__, _, [:Ecto, :Query]}, :from]}, _, _} ->
@@ -108,9 +108,30 @@ defmodule Quokka.Style.CommentDirectives do
     end_line > start_line && Enum.any?(comments, &(&1.line > start_line && &1.line < end_line))
   end
 
+  # Sorts a list with numeric-aware comparison for map keys
+  # Preserves existing behavior of sorting mixed atom/string keys alphabetically
+  defp numeric_aware_sort(list) do
+    # Check if all elements have numeric keys
+    if Enum.all?(list, &numeric_key?/1) do
+      # Sort numerically by the numeric key (handles both integers and floats)
+      Enum.sort_by(list, &extract_key/1)
+    else
+      # Fall back to string-based sorting to handle mixed atom/string keys
+      # This ensures {:b, _} and {"b", _} sort together
+      Enum.sort_by(list, &Macro.to_string/1)
+    end
+  end
+
+  defp numeric_key?({{:__block__, _, [key]}, _}) when is_number(key), do: true
+  defp numeric_key?({key, _}) when is_number(key), do: true
+  defp numeric_key?(_), do: false
+
+  defp extract_key({{:__block__, _, [key]}, _}), do: key
+  defp extract_key({key, _}), do: key
+
   # defstruct with a syntax-sugared keyword list hits here
   defp sort({parent, meta, [list]} = node, comments) when parent in ~w(defstruct __block__)a and is_list(list) do
-    list = Enum.sort_by(list, &Macro.to_string/1)
+    list = numeric_aware_sort(list)
     line = meta[:line]
     # no need to fix line numbers if it's a single line structure
     {list, comments} =
@@ -200,7 +221,7 @@ defmodule Quokka.Style.CommentDirectives do
     sorted_groups =
       field_type_order
       |> Enum.map(fn type ->
-        grouped_fields |> Map.get(type, []) |> Enum.sort_by(&Macro.to_string/1)
+        grouped_fields |> Map.get(type, []) |> numeric_aware_sort()
       end)
       |> Enum.reject(&(&1 == []))
 
@@ -209,7 +230,7 @@ defmodule Quokka.Style.CommentDirectives do
       |> Map.drop(field_type_order)
       |> Map.values()
       |> List.flatten()
-      |> Enum.sort_by(&Macro.to_string/1)
+      |> numeric_aware_sort()
 
     sorted_fields =
       sorted_groups
@@ -236,7 +257,7 @@ defmodule Quokka.Style.CommentDirectives do
 
       {nodes, comments} =
         nodes
-        |> Enum.sort_by(&Macro.to_string/1)
+        |> numeric_aware_sort()
         |> Style.order_line_meta_and_comments(comments, m[:line])
 
       args = List.insert_at(args, -1, [{{:__block__, m1, [:do]}, {:__block__, m2, nodes}}])

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -256,6 +256,53 @@ defmodule Quokka.Style.CommentDirectivesTest do
       )
     end
 
+    test "autosorts maps with numeric keys" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+
+      # Integer keys
+      assert_style(
+        """
+        %{10 => "ten", 1 => "one", 2 => "two", 20 => "twenty"}
+        """,
+        """
+        %{1 => "one", 2 => "two", 10 => "ten", 20 => "twenty"}
+        """
+      )
+
+      # Float keys
+      assert_style(
+        """
+        %{10.5 => "ten-five", 1.5 => "one-five", 2.0 => "two", 20.1 => "twenty-one"}
+        """,
+        """
+        %{1.5 => "one-five", 2.0 => "two", 10.5 => "ten-five", 20.1 => "twenty-one"}
+        """
+      )
+
+      # Mixed numeric keys
+      assert_style(
+        """
+        %{10 => "ten", 1.5 => "one-five", 2 => "two", 20.0 => "twenty"}
+        """,
+        """
+        %{1.5 => "one-five", 2 => "two", 10 => "ten", 20.0 => "twenty"}
+        """
+      )
+    end
+
+    test "autosorts maps with mixed atom and string keys" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+
+      assert_style(
+        """
+        %{:b => 1, "a" => 2, :c => 3}
+        """,
+        """
+        %{"a" => 2, :b => 1, :c => 3}
+        """
+      )
+    end
+
     test "autosorts ecto queries" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
 


### PR DESCRIPTION
Fixes #102

## Summary
- Maps with numeric keys now sort in numeric order (1, 2, 10, 20) rather than lexicographic order (1, 10, 2, 20)
- Mixed key types continue to use string-based sorting to preserve existing behavior for atom/string keys

## Test plan
- [x] Added tests for integer key sorting
- [x] Added tests for float key sorting  
- [x] Added tests for mixed numeric key sorting
- [x] Added tests for mixed atom/string key sorting
- [x] All existing tests pass
- [x] Credo linting passes
- [x] Code formatted with mix format