### PR TITLE
Fix error handling to prevent outright crashes

### DIFF
--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -50,7 +50,7 @@ defmodule Quokka do
             if on_error == :log do
               error = Exception.format(:error, exception, __STACKTRACE__)
               Mix.shell().error("#{error}\n#{IO.ANSI.reset()}Skipping style and continuing on")
-              {zipper, context}
+              {zipper, comments}
             else
               reraise exception, __STACKTRACE__
             end


### PR DESCRIPTION
In the course of diagnosing why Quokka was crashing on my codebase at work (fix for the crash itself in #120), I was getting errors like this when Quokka rescued an exception:

```
mix format failed for file: lib/jump_web/live/sharing_component.ex
** (FunctionClauseError) no function clause matching in Code.Formatter.format_comment/1

    The following arguments were given to Code.Formatter.format_comment/1:

        # 1
        {:file, "/Users/tyler/jump/api/lib/jump_web/live/sharing_component.ex"}

    Attempted function clauses (showing 1 out of 1):

        defp format_comment(%{text: text} = comment)

    (elixir 1.18.3) lib/code/formatter.ex:227: Code.Formatter.format_comment/1
    (elixir 1.18.3) lib/enum.ex:1722: anonymous fn/3 in Enum.map/2
    (stdlib 6.2) maps.erl:860: :maps.fold_1/4
    (elixir 1.18.3) lib/enum.ex:2558: Enum.map/2
    (elixir 1.18.3) lib/code/formatter.ex:162: Code.Formatter.to_algebra/2
    (quokka 2.11.0) lib/styler.ex:119: Quokka.ast_to_string/3
    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.18.3) lib/mix/tasks/format.ex:715: Mix.Tasks.Format.format_file/2
```

The errors wound up being quote far from where the problem actually occurred—in `style.ex`, we were using the whole context as the second value in the tuple, when other portions of the same reduce pass only the comments.

I'm not sure what to do to test this, because of course if we were aware of a crash in a style function, we'd fix the crash. You can repro using the goofy capture in #120, though.
