### PR TITLE
Fix crash in sorting when all schema field definitions occur through a macro

### DIFF
--- a/lib/style/comment_directives.ex
+++ b/lib/style/comment_directives.ex
@@ -270,12 +270,16 @@ defmodule Quokka.Style.CommentDirectives do
       |> numeric_aware_sort()
 
     sorted_fields =
-      sorted_groups
-      |> Enum.map(&Style.reset_newlines/1)
-      |> Enum.reduce(fn group, acc ->
-        acc ++ Style.reset_newlines(group)
-      end)
-      |> Kernel.++(other_fields)
+      if Enum.empty?(sorted_groups) do
+        other_fields
+      else
+        sorted_groups
+        |> Enum.map(&Style.reset_newlines/1)
+        |> Enum.reduce(fn group, acc ->
+          acc ++ Style.reset_newlines(group)
+        end)
+        |> Kernel.++(other_fields)
+      end
 
     Style.order_line_meta_and_comments(sorted_fields, comments, meta_line)
   end

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -220,6 +220,25 @@ defmodule Quokka.Style.CommentDirectivesTest do
       )
     end
 
+    test "does not attempt to autosort schema fields passed through macros" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:schema] end)
+
+      assert_style(
+        """
+        embedded_schema do
+          optional :number, :string
+          optional :principal, :boolean, default: false
+        end
+        """,
+        """
+        embedded_schema do
+          optional(:number, :string)
+          optional(:principal, :boolean, default: false)
+        end
+        """
+      )
+    end
+
     test "autosorts even after comment directive" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:schema] end)
 


### PR DESCRIPTION
Hi Emily! Thanks so much for your quick reviews and releases. They are tremendously appreciated. I'm thiiiiis close to being able to use v2.11.x at work, and I'm extremely excited for all the improvements.

Speaking of work... we have a macro called `optional` which improves the Absinthe schema we generate from our schemas. On the tip of main, I was seeing the formatter crash when formatting those files, with the error:

```
** (Quokka.StyleError) Error running style CommentDirectives on lib/jump/contacts/schema.ex
   Please consider opening an issue at: https://github.com/smartrent/quokka/issues/new
** (Enum.EmptyError) empty error

    (elixir 1.18.3) lib/enum.ex:2489: Enum.reduce/2
    (quokka 2.11.1) lib/style/comment_directives.ex:275: Quokka.Style.CommentDirectives.sort_schema_fields/3
    (quokka 2.11.1) lib/style/comment_directives.ex:201: Quokka.Style.CommentDirectives.sort/2
    (quokka 2.11.1) lib/style/comment_directives.ex:63: Quokka.Style.CommentDirectives.run/2
    (quokka 2.11.1) lib/zipper.ex:383: Quokka.Zipper.do_traverse_while/3
    (quokka 2.11.1) lib/styler.ex:44: anonymous fn/4 in Quokka.apply_styles/3
    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (quokka 2.11.1) lib/styler.ex:40: Quokka.apply_styles/3

Skipping style and continuing on
```

I've confirmed this fixes our issue, and added a test that demonstrates the code path.