### PR TITLE
Sort nested module directives

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -36,7 +36,7 @@ alias Foo.Bop
 ## Directive Organization
 
 This addresses:
-- [`Credo.Check.Readability.AliasOrder`](https://hexdocs.pm/credo/Credo.Check.Readability.AliasOrder.html). While it is not possible to disable this rewrite, Quokka will respect the `:sort_method` Credo config.
+- [`Credo.Check.Readability.AliasOrder`](https://hexdocs.pm/credo/Credo.Check.Readability.AliasOrder.html). While it is not possible to disable this rewrite, Quokka will respect the `:sort_method` Credo config. Note that nested aliases are sorted within their group as well.
 - [`Credo.Check.Readability.StrictModuleLayout`](https://hexdocs.pm/credo/Credo.Check.Readability.StrictModuleLayout.html). While it is not possible to disable this rewrite, Quokka will respect the `:order` Credo config.
 
 Modules directives are sorted into the following order by default:
@@ -56,6 +56,7 @@ Modules directives are sorted into the following order by default:
 defmodule Foo do
   @behaviour Lawful
   alias A.A
+  alias __MODULE__.{C, B.D}
   require A
 
   use B
@@ -111,6 +112,7 @@ defmodule Foo do
   import A.A
   import C
 
+  alias __MODULE__.{B.D, C}
   alias A.A
   alias C.C
   alias D.D

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -222,7 +222,7 @@ defmodule Quokka.Style.ModuleDirectives do
 
         {directive, _, _} = ast, acc when directive in @directives ->
           {ast, acc} = lift_module_attrs(ast, acc)
-          ast = if Quokka.Config.rewrite_multi_alias?(), do: expand(ast), else: [ast]
+          ast = if Quokka.Config.rewrite_multi_alias?(), do: expand(ast), else: [sort_multi_children(ast)]
 
           # import and use might get hoisted above aliases, so need to dealias depending on the layout order
           needs_dealiasing = directive in ~w(import use)a and Enum.member?(before, directive)
@@ -524,19 +524,32 @@ defmodule Quokka.Style.ModuleDirectives do
 
   defp expand(other), do: [other]
 
+  # When multi directives are not expanded, maintain brace form but sort inner items
+  defp sort_multi_children({directive, dm, [{{:., m, [{left_type, _, _} = left, :{}]}, meta, right}]})
+       when directive in @directives and left_type in [:__aliases__, :__MODULE__] do
+    {directive, dm, [{{:., m, [left, :{}]}, meta, sort_terms(right)}]}
+  end
+
+  defp sort_multi_children(other), do: other
+
   defp sort(directives) do
-    directive_strings =
-      if Quokka.Config.sort_order() == :ascii do
-        Enum.map(directives, &{&1, Macro.to_string(&1)})
-      else
-        Enum.map(directives, &{&1, &1 |> Macro.to_string() |> String.downcase()})
+    directives
+    |> sort_terms()
+    |> Style.reset_newlines()
+  end
+
+  defp sort_terms(asts) do
+    compare_key =
+      case Quokka.Config.sort_order() do
+        :ascii -> &Macro.to_string/1
+        _alpha -> fn ast -> ast |> Macro.to_string() |> String.downcase() end
       end
 
-    directive_strings
+    asts
+    |> Enum.map(&{&1, compare_key.(&1)})
     |> Enum.uniq_by(&elem(&1, 1))
     |> List.keysort(1)
     |> Enum.map(&elem(&1, 0))
-    |> Style.reset_newlines()
   end
 
   defp has_skip_comment?(context) do

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -499,10 +499,46 @@ defmodule Quokka.Style.ModuleDirectivesTest do
       alias A.{B, C}
       """)
 
-      assert_style("""
-      alias A.D
-      alias A.{B, E, C}
-      """)
+      assert_style(
+        """
+        alias A.D
+        alias A.{B, E, C}
+        """,
+        """
+        alias A.D
+        alias A.{B, C, E}
+        """
+      )
+    end
+
+    test "sorts nested alias/import/require braces when not expanded" do
+      stub(Quokka.Config, :rewrite_multi_alias?, fn -> false end)
+
+      assert_style(
+        """
+        alias A.{C, B, E}
+        require Bar.{B, A}
+        import Foo.{Z, A, M}
+        """,
+        """
+        import Foo.{A, M, Z}
+
+        alias A.{B, C, E}
+
+        require Bar.{A, B}
+        """
+      )
+
+      assert_style(
+        """
+        alias A.A
+        alias __MODULE__.{C, B.D, B.A, A}
+        """,
+        """
+        alias __MODULE__.{A, B.A, B.D, C}
+        alias A.A
+        """
+      )
     end
   end
 


### PR DESCRIPTION
## Description

Currently code like this would stay untouched:
```
alias A.{B, E, C}
```

However, Credo.Check.Readability.AliasOrder complains about this, stating that
```
The alias `A.E` is not alphabetically ordered among its group.
```

## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
