### PR TITLE
Add support for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ### Improvements
 
+- Added support for plugins; see `Quokka.Plugin` docs for details on creating your own formatting rules.
 - Rewrite `Enum.reduce/2,3` calls that simply sum their two arguments to `Enum.sum/1` (part of inefficient function rewrites).
 - Respect Credo's `Credo.Check.Readability.StrictModuleLayout` `ignore_module_attributes` and `ignore: [:module_attribute]` options. When a module contains an ignored module attribute, Quokka preserves the original directive order for that module rather than hoisting directives above the attribute (which could be referenced by an earlier-ordered directive such as `@moduledoc`). Fixes [#137](https://github.com/smartrent/quokka/issues/137).
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ in `.formatter.exs` to fine tune your setup:
       | piped_functions: [:subquery, :"Repo.update", ...]
       # Don't rewrite `case foo |> bar() |> baz() do` into `foo |> bar() |> baz() |> case do`
       | :pipe_into_case
+    ],
+    requires: [
+      # Files matched by the `:requires` list will be compiled for use in the plugin system
+      "lib/my_app/quokka_plugins/*.ex"
+    ],
+    plugins: [
+      MyApp.Quokka.Plugin1,
+      {MyApp.Quokka.Plugin2, option_1: "value", option_2: "other"}
     ]
   ]
 ]
@@ -202,6 +210,10 @@ Beyond Credo-inspired checks, Quokka provides additional style improvements:
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
 | Test Styling | Rewrites tests to be efficent and idiomatic | [Test Assertions](docs/tests.md) |
+
+## Custom rewrites
+
+Quokka supports writing your own plugins to get behavior that goes beyond (or even contradicts) the built-in styles. See the docs on `Quokka.Plugin` for more information.
 
 ## License
 

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -96,6 +96,10 @@ defmodule Quokka.Config do
     quokka_config = formatter_opts[:quokka] || []
     credo_opts = extract_configs_from_credo()
 
+    # Load and validate plugins
+    load_required_files(quokka_config[:requires] || [])
+    {plugins, plugin_opts} = parse_plugins(quokka_config[:plugins] || [])
+
     lift_alias_excluded_namespaces = credo_opts[:lift_alias_excluded_namespaces] || []
 
     lift_alias_excluded_lastnames = credo_opts[:lift_alias_excluded_lastnames] || []
@@ -183,6 +187,8 @@ defmodule Quokka.Config do
         pipe_chain_start_flag: credo_opts[:pipe_chain_start_flag] || false,
         pipe_into_case_flag: :pipe_into_case not in exclude_rules,
         piped_function_exclusions: piped_function_exclusions,
+        plugin_opts: plugin_opts,
+        plugins: plugins,
         rewrite_multi_alias: credo_opts[:rewrite_multi_alias] || false,
         single_pipe_flag: credo_opts[:single_pipe_flag] || false,
         sort_order: credo_opts[:sort_order] || :alpha,
@@ -225,13 +231,18 @@ defmodule Quokka.Config do
       |> Enum.reject(&is_nil/1)
       |> MapSet.new()
 
-    Enum.filter(@style_pipeline, fn
-      CommentDirectives ->
-        true
+    builtin_styles =
+      Enum.filter(@style_pipeline, fn
+        CommentDirectives ->
+          true
 
-      style ->
-        MapSet.member?(enabled_styles, style) and not MapSet.member?(excluded_styles, style)
-    end)
+        style ->
+          MapSet.member?(enabled_styles, style) and not MapSet.member?(excluded_styles, style)
+      end)
+
+    # Plugins run after built-in styles, in declaration order
+    plugins = get(:plugins) || []
+    builtin_styles ++ plugins
   end
 
   def only_styles() do
@@ -375,6 +386,18 @@ defmodule Quokka.Config do
     get(:zero_arity_parens)
   end
 
+  def plugins() do
+    get(:plugins)
+  end
+
+  def plugin_opts() do
+    get(:plugin_opts)
+  end
+
+  def plugin_opts(module) do
+    get(:plugin_opts)[module] || []
+  end
+
   def allowed_directory?(file) do
     relative_path = Path.relative_to_cwd(file)
     included_dirs = get(:directories_included)
@@ -480,4 +503,38 @@ defmodule Quokka.Config do
         System.version()
     end
   end
+
+  defp load_required_files(patterns) do
+    patterns
+    |> List.wrap()
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.each(fn path ->
+      if File.exists?(path) do
+        Code.require_file(path)
+      else
+        Logger.warning("Quokka plugin file not found: #{path}")
+      end
+    end)
+  end
+
+  defp parse_plugins(plugin_specs) do
+    {modules, module_opts} =
+      Enum.reduce(plugin_specs, {[], %{}}, fn spec, {modules, opts_map} = acc ->
+        {module, opts} = normalize_plugin_spec(spec)
+
+        case Quokka.Plugin.validate(module) do
+          {:ok, module} ->
+            {[module | modules], Map.put(opts_map, module, opts)}
+
+          {:error, reason} ->
+            Logger.warning("Invalid Quokka plugin:\n\n#{inspect(reason)}")
+            acc
+        end
+      end)
+
+    {Enum.reverse(modules), module_opts}
+  end
+
+  defp normalize_plugin_spec({module, opts}) when is_atom(module) and is_list(opts), do: {module, opts}
+  defp normalize_plugin_spec(module) when is_atom(module), do: {module, []}
 end

--- a/lib/quokka/plugin.ex
+++ b/lib/quokka/plugin.ex
@@ -1,0 +1,109 @@
+defmodule Quokka.Plugin do
+  @moduledoc """
+  Provides support for writing Quokka plugins.
+
+  Plugins are custom style rules that integrate with the Quokka auto-formatter.
+  They run after all built-in styles, in the order they are declared in your
+  `.formatter.exs` configuration.
+
+  ## Usage
+
+  Create a module that uses `Quokka.Plugin` and implements the `run/2` callback:
+
+      defmodule MyApp.Styles.CurlyQuotes do
+        use Quokka.Plugin, description: "Converts straight quotes to curly quotes in strings"
+
+        @impl Quokka.Style
+        def run({{:__block__, [{:delimiter, ~s(")} | _] = node_meta, [string]}, zipper_meta}, ctx)
+            when is_binary(string) do
+          new_string = String.replace(string, "'s", "’s")
+          {:cont, {{:__block__, node_meta, [new_string]}, zipper_meta}, ctx}
+        end
+
+        def run(zipper, ctx), do: {:cont, zipper, ctx}
+      end
+
+  ## Configuration
+
+  Register plugins in your `.formatter.exs`:
+
+      [
+        plugins: [Quokka],
+        inputs: ["lib/**/*.ex", "test/**/*.exs"],
+        quokka: [
+          requires: ["lib/my_app/quokka_plugins/*.ex"],
+          plugins: [
+            MyApp.Styles.CurlyQuotes,
+            {MyApp.Styles.CustomRule, option_1: "value", option_2: "other"}
+          ]
+        ]
+      ]
+
+  ## Execution Order
+
+  1. Built-in styles run first (in their internal order)
+  2. Plugins run after, in the order declared in `.formatter.exs`
+
+  This means plugins get "the last word" on styling and can modify or undo
+  what built-in styles did.
+
+  ## Plugin Options
+
+  The `use Quokka.Plugin` macro accepts:
+
+  - `:description` - A short description of what the plugin does
+
+  ## Accessing Configuration
+
+  If your plugin is registered with options like `{MyPlugin, foo: "bar"}`,
+  you can access those options via `ctx.plugin_opts`:
+
+      def run(zipper, %{plugin_opts: opts} = ctx) do
+        foo = Keyword.get(opts, :foo, "default")
+        # ...
+      end
+  """
+
+  @doc """
+  Returns metadata about a plugin module.
+
+  ## Keys
+
+  - `:description` - The plugin's description
+  - `:all` - All options passed to `use Quokka.Plugin`
+  """
+  @callback __quokka_plugin__(atom()) :: term()
+
+  @optional_callbacks __quokka_plugin__: 1
+
+  defmacro __using__(opts) do
+    quote do
+      @behaviour Quokka.Style
+
+      @quokka_plugin_opts unquote(opts)
+
+      @doc false
+      def __quokka_plugin__(:description), do: @quokka_plugin_opts[:description]
+      def __quokka_plugin__(:all), do: @quokka_plugin_opts
+    end
+  end
+
+  @doc """
+  Validates that a module is a valid Quokka plugin.
+
+  Returns `{:ok, module}` if valid, or `{:error, reason}` if not.
+  """
+  @spec validate(module()) :: {:ok, module()} | {:error, String.t()}
+  def validate(module) when is_atom(module) do
+    cond do
+      not Code.ensure_loaded?(module) ->
+        {:error, "module #{inspect(module)} could not be loaded"}
+
+      not function_exported?(module, :run, 2) ->
+        {:error, "module #{inspect(module)} must implement run/2 callback"}
+
+      true ->
+        {:ok, module}
+    end
+  end
+end

--- a/lib/style.ex
+++ b/lib/style.ex
@@ -21,7 +21,8 @@ defmodule Quokka.Style do
 
   @type context :: %{
           comments: [map()],
-          file: :stdin | String.t()
+          file: :stdin | String.t(),
+          plugin_opts: keyword()
         }
 
   @doc """

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -36,9 +36,11 @@ defmodule Quokka do
     on_error = opts[:on_error] || :log
     zipper = Zipper.zip(ast)
 
+    plugin_opts = Quokka.Config.plugin_opts()
+
     {{ast, _}, comments} =
       Enum.reduce(Quokka.Config.get_styles(), {zipper, comments}, fn style, {zipper, comments} ->
-        context = %{comments: comments, file: file}
+        context = %{comments: comments, file: file, plugin_opts: Map.get(plugin_opts, style, [])}
 
         try do
           {zipper, %{comments: comments}} = Zipper.traverse_while(zipper, context, &style.run/2)

--- a/test/plugin_test.exs
+++ b/test/plugin_test.exs
@@ -1,0 +1,219 @@
+defmodule Quokka.Test.Plugins.CurlyQuotes do
+  @moduledoc """
+  A sample Quokka plugin that transforms straight apostrophes in possessives
+  (like `'s`) to curly apostrophes (`’s`) within string literals.
+
+  This serves as an example of how to write a Quokka plugin and is used in tests.
+  """
+  use Quokka.Plugin, description: "Converts straight apostrophes to curly quotes in strings"
+
+  @default_patterns [{"'s", "’s"}]
+
+  @impl Quokka.Style
+  def run({{:__block__, [{:delimiter, ~s(")} | _] = node_meta, [string]}, zipper_meta}, ctx) when is_binary(string) do
+    patterns = Keyword.get(ctx.plugin_opts, :patterns, @default_patterns)
+    new_string = apply_replacements(string, patterns)
+    {:cont, {{:__block__, node_meta, [new_string]}, zipper_meta}, ctx}
+  end
+
+  def run(zipper, ctx), do: {:cont, zipper, ctx}
+
+  defp apply_replacements(string, patterns) do
+    Enum.reduce(patterns, string, fn {from, to}, acc ->
+      String.replace(acc, from, to)
+    end)
+  end
+end
+
+defmodule Quokka.Test.Plugins.StraightQuotes do
+  @moduledoc "Transforms all curly single quotes to straight quotes in strings."
+  use Quokka.Plugin, description: "Converts curly single quotes to straight quotes in strings"
+
+  @impl Quokka.Style
+  def run({{:__block__, [{:delimiter, ~s(")} | _] = node_meta, [string]}, zipper_meta}, ctx) when is_binary(string) do
+    new_string = String.replace(string, "’", "'")
+    {:cont, {{:__block__, node_meta, [new_string]}, zipper_meta}, ctx}
+  end
+
+  def run(zipper, ctx), do: {:cont, zipper, ctx}
+end
+
+defmodule NoRunCallback do
+  def not_run(_, _), do: :ok
+end
+
+defmodule Quokka.PluginTest do
+  # Can't be async because it monkeys with the global config to add a plugin
+  use Quokka.StyleCase, async: false
+  use Mimic
+
+  import ExUnit.CaptureLog
+
+  alias Quokka.Style.SingleNode
+  alias Quokka.Test.Plugins.CurlyQuotes
+  alias Quokka.Test.Plugins.StraightQuotes
+
+  setup do
+    on_exit(fn ->
+      Quokka.Config.set!(quokka: [plugins: []])
+    end)
+
+    :ok
+  end
+
+  describe "Quokka.Plugin.validate/1" do
+    test "validates a module with run/2 callback" do
+      assert {:ok, CurlyQuotes} = Quokka.Plugin.validate(CurlyQuotes)
+    end
+
+    test "returns error for module without run/2" do
+      assert {:error, message} = Quokka.Plugin.validate(NoRunCallback)
+      assert message =~ "must implement run/2"
+    end
+
+    test "returns error for non-existent module" do
+      assert {:error, message} = Quokka.Plugin.validate(NonExistentModule)
+      assert message =~ "could not be loaded"
+    end
+  end
+
+  describe "plugin registration in config" do
+    test "registers plugins from config" do
+      assert :ok = Quokka.Config.set!(quokka: [plugins: [CurlyQuotes]])
+      assert CurlyQuotes in Quokka.Config.plugins()
+    end
+
+    test "registers plugins with options" do
+      assert :ok = Quokka.Config.set!(quokka: [plugins: [{CurlyQuotes, patterns: [{"'t", "'t"}]}]])
+      assert CurlyQuotes in Quokka.Config.plugins()
+      assert [patterns: [{"'t", "'t"}]] = Quokka.Config.plugin_opts(CurlyQuotes)
+    end
+
+    test "plugins appear after built-in styles in get_styles" do
+      assert :ok = Quokka.Config.set!(quokka: [plugins: [CurlyQuotes]])
+      styles = Quokka.Config.get_styles()
+
+      # CurlyQuotes should be last
+      assert List.last(styles) == CurlyQuotes
+
+      # Built-in styles should come before
+      assert SingleNode in styles
+      single_node_index = Enum.find_index(styles, &(&1 == SingleNode))
+      curly_quotes_index = Enum.find_index(styles, &(&1 == CurlyQuotes))
+      assert single_node_index < curly_quotes_index
+    end
+
+    test "plugins run in declaration order" do
+      assert :ok =
+               Quokka.Config.set!(
+                 quokka: [
+                   plugins: [
+                     {CurlyQuotes, patterns: [{"'t", "'t"}]},
+                     StraightQuotes
+                   ]
+                 ]
+               )
+
+      assert_style(
+        """
+        defmodule Foo do
+          def bar(), do: "the dog's bone"
+          def baz(), do: "the cat’s bowl"
+        end
+        """,
+        """
+        defmodule Foo do
+          def bar(), do: "the dog's bone"
+          def baz(), do: "the cat's bowl"
+        end
+        """
+      )
+    end
+
+    test "warns about invalid plugins" do
+      log =
+        capture_log(fn ->
+          Quokka.Config.set!(quokka: [plugins: [NoRunCallback]])
+        end)
+
+      assert log =~ "Invalid Quokka plugin"
+      refute NoRunCallback in Quokka.Config.plugins()
+    end
+  end
+
+  describe "CurlyQuotes plugin" do
+    setup do
+      Quokka.Config.set!(quokka: [plugins: [CurlyQuotes]])
+      :ok
+    end
+
+    test "transforms straight apostrophe to curly in double-quoted strings" do
+      assert_style(
+        """
+        defmodule Foo do
+          def bar(), do: "the dog's bone"
+        end
+        """,
+        """
+        defmodule Foo do
+          def bar(), do: "the dog’s bone"
+        end
+        """
+      )
+    end
+
+    test "transforms multiple occurrences" do
+      assert_style(
+        """
+        defmodule Foo do
+          @module_attr "the girl's ball and the boy's toy"
+
+          def bar(), do: "the dog's bone and cat's toy"
+
+        end
+        """,
+        """
+        defmodule Foo do
+          @module_attr "the girl’s ball and the boy’s toy"
+
+          def bar(), do: "the dog’s bone and cat’s toy"
+        end
+        """
+      )
+    end
+
+    test "leaves strings without apostrophes unchanged" do
+      assert_style(
+        """
+        defmodule Foo do
+          def bar(), do: "the dog and cat"
+        end
+        """,
+        """
+        defmodule Foo do
+          def bar(), do: "the dog and cat"
+        end
+        """
+      )
+    end
+
+    test "respects custom patterns from plugin options" do
+      Quokka.Config.set!(quokka: [plugins: [{CurlyQuotes, patterns: [{"'t", "’t"}]}]])
+
+      assert_style(
+        """
+        defmodule Foo do
+          def bar(), do: "the dog's and cat's"
+          def baz(), do: "don't do that"
+        end
+        """,
+        """
+        defmodule Foo do
+          def bar(), do: "the dog's and cat's"
+          def baz(), do: "don’t do that"
+        end
+        """
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a plugin system for Quokka, enabling users of the library to add custom behavior to their auto-formatting.

I weighed a few different options for _when_ the plugins should run, including things like having a "priority" system where plugins could declare they want to run before all built-in styles, after a specific style, after all built-in styles, or after all other plugins. However, I ultimately concluded that if plugins wanted to "fight" with the built-in styles (or worse, with other plugins!), we should just let the plugins have the last word. Thus, in the current design, we simply run all plugins in the order they're declared within the `.formatter.exs`; if there are conflicting rewrites, the last listed plugin "wins."

The docs for `plugin.ex` contain a minimal example of both creating a plugin and configuring your `.formatter.exs` to use one.

(Resolves #135)

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [N/A] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
