### PR TITLE
fix: ensure empty modules don't crash formatting

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -78,10 +78,9 @@ defmodule Quokka.Style.ModuleDirectives do
           |> Zipper.right()
 
         case Zipper.node(body_zipper) do
-          # an empty body - replace it with a moduledoc and call it a day ¯\_(ツ)_/¯
+          # an empty body - Leave it alone
           {:__block__, _, []} ->
-            zipper = if moduledoc, do: Zipper.replace(body_zipper, moduledoc), else: body_zipper
-            {:skip, zipper, ctx}
+            {:skip, body_zipper, ctx}
 
           # we want only-child literal block to be handled in the only-child catch-all. it means someone did a weird
           # (that would be a literal, so best case someone wrote a string and forgot to put `@moduledoc` before it)

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -59,6 +59,8 @@ defmodule Quokka.Zipper do
   defp do_replace_children({_form, meta, args}, [first | rest]) when is_list(args), do: {first, meta, rest}
 
   defp do_replace_children({_, _}, [left, right]), do: {left, right}
+  defp do_replace_children({_, _}, [single]), do: single
+  defp do_replace_children({_, _}, []), do: nil
   defp do_replace_children(list, children) when is_list(list), do: children
 
   @doc """

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -583,6 +583,16 @@ defmodule Quokka.Style.ModuleDirectivesTest do
       end
       """)
     end
+
+    test "empty defmodule inside quote do...end does not crash" do
+      assert_style("""
+      ast =
+        quote do
+          defmodule Foo.Bar.Baz do
+          end
+        end
+      """)
+    end
   end
 
   describe "directive sort/dedupe/expansion" do

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -41,6 +41,14 @@ defmodule QuokkaTest.ZipperTest do
       assert {1, 2} |> Zipper.zip() |> Zipper.replace_children([3, 4]) |> Zipper.node() == {3, 4}
     end
 
+    test "2-tuples with single child collapses" do
+      assert {1, 2} |> Zipper.zip() |> Zipper.replace_children([3]) |> Zipper.node() == 3
+    end
+
+    test "2-tuples with no children collapses to nil" do
+      assert {1, 2} |> Zipper.zip() |> Zipper.replace_children([]) |> Zipper.node() == nil
+    end
+
     test "lists" do
       assert [1, 2, 3] |> Zipper.zip() |> Zipper.replace_children([:a, :b, :c]) |> Zipper.node() ==
                [:a, :b, :c]
@@ -501,6 +509,27 @@ defmodule QuokkaTest.ZipperTest do
              |> Zipper.remove()
              |> Zipper.remove()
              |> Zipper.node() == []
+    end
+
+    test "removes the left child of a 2-tuple" do
+      zipper =
+        {1, 2}
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.remove()
+
+      assert Zipper.root(zipper) == 2
+    end
+
+    test "removes the right child of a 2-tuple" do
+      zipper =
+        {1, 2}
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.right()
+        |> Zipper.remove()
+
+      assert Zipper.root(zipper) == 1
     end
 
     test "raises when attempting to remove the root" do


### PR DESCRIPTION
## Description

While writing some unit tests, I created a defmodule inside of a quote block. The defmodule had no contents, and this crashed quokka.

This is because quokka's zipper implementation didn't handle removing a the placeholder node it adds for moduledoc on an empty module body.

Hopefully, now it can.

## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
