### PR TITLE
[feat] Add ability to sort struct fields in types

### DIFF
--- a/docs/comment_directives.md
+++ b/docs/comment_directives.md
@@ -63,6 +63,13 @@ a_var =
     A,
     List
   ]
+
+# quokka:sort
+@type t :: %__MODULE__{
+  c: String.t(),
+  a: boolean(),
+  b: pos_integer()
+}
 ```
 
 Would yield:
@@ -90,6 +97,13 @@ a_var =
     List,
     Modules
   ]
+
+# quokka:sort
+@type t :: %__MODULE__{
+  a: boolean(),
+  b: pos_integer,
+  c: String.t()
+}
 ```
 
 ## Autosort

--- a/lib/style/comment_directives.ex
+++ b/lib/style/comment_directives.ex
@@ -192,9 +192,16 @@ defmodule Quokka.Style.CommentDirectives do
     {{:=, m, [lhs, rhs]}, comments}
   end
 
-  defp sort({:@, m, [{a, am, [assignment]}]}, comments) do
+  # @type / @typep — sort struct fields (e.g. `@type t :: %__MODULE__{...}`)
+  defp sort({:@, attr_meta, [{attr, annotation_meta, [{:"::", spec_meta, [lhs, rhs]}]}]}, comments)
+       when attr in [:type, :typep] do
+    {rhs, comments} = sort(rhs, comments)
+    {{:@, attr_meta, [{attr, annotation_meta, [{:"::", spec_meta, [lhs, rhs]}]}]}, comments}
+  end
+
+  defp sort({:@, attr_meta, [{attr, annotation_meta, [assignment]}]}, comments) do
     {assignment, comments} = sort(assignment, comments)
-    {{:@, m, [{a, am, [assignment]}]}, comments}
+    {{:@, attr_meta, [{attr, annotation_meta, [assignment]}]}, comments}
   end
 
   defp sort({:embedded_schema, meta, [[{{:__block__, _, [:do]}, {:__block__, block_meta, fields}}]]}, comments) do

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -665,7 +665,7 @@ defmodule Quokka.Style.CommentDirectivesTest do
 
   describe "sort" do
     test "we dont just sort by accident" do
-      assert_style "[:c, :b, :a]"
+      assert_style("[:c, :b, :a]")
     end
 
     test "sorts lists of atoms" do
@@ -982,6 +982,58 @@ defmodule Quokka.Style.CommentDirectivesTest do
         ]
         """
       )
+    end
+
+    test "sorts @type struct fields" do
+      assert_style(
+        """
+        # quokka:sort
+        @type t :: %__MODULE__{
+                title: String.t(),
+                id: integer(),
+                name: String.t()
+              }
+        """,
+        """
+        # quokka:sort
+        @type t :: %__MODULE__{
+                id: integer(),
+                name: String.t(),
+                title: String.t()
+              }
+        """
+      )
+    end
+
+    test "sorts @type named struct fields" do
+      assert_style(
+        """
+        # quokka:sort
+        @type t :: %MyStruct{
+                title: String.t(),
+                id: integer(),
+                name: String.t()
+              }
+        """,
+        """
+        # quokka:sort
+        @type t :: %MyStruct{
+                id: integer(),
+                name: String.t(),
+                title: String.t()
+              }
+        """
+      )
+    end
+
+    test "does not sort @type struct fields without directive" do
+      assert_style("""
+      @type t :: %__MODULE__{
+              title: String.t(),
+              id: integer(),
+              name: String.t()
+            }
+      """)
     end
 
     test "nodes within a do end block" do


### PR DESCRIPTION
## Description

The quokka:sort directive is neat, but it doesn't work for stuct keys in types, i.e.
```elixir
@type %__MODULE__{
 id: id(),
 key: String.t(),
 value: term()
}
```

This is a small change that allows for sorting these keys.

## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
