### PR TITLE
feat (inefficient function rewrites): Rewrite `Enum.reduce/{2,3}` to `Enum.sum/1` when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+### Improvements
+
+- Rewrite `Enum.reduce/2,3` calls that simply sum their two arguments to `Enum.sum/1` (part of inefficient function rewrites).
+
 ## [2.12.1] - 2025-02-12
 
 ### Fixes

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -170,6 +170,22 @@ baz |> Enum.reverse() |> Enum.concat(bop)
 Enum.reverse(baz, bop)
 ```
 
+### `Enum.reduce` summing -> `Enum.sum`
+
+Quokka rewrites `Enum.reduce/2,3` calls whose reducer simply adds the two arguments to `Enum.sum/1`. This covers anonymous functions (with operands in either order), `&(&1 + &2)` captures, and `&+/2` / `&Kernel.+/2` captures. For `Enum.reduce/3`, the accumulator must be the literal integer `0` (so `0.0` is left alone to preserve float typing on empty enums).
+
+```elixir
+# Before
+Enum.reduce(enum, 0, fn x, acc -> x + acc end)
+# Styled
+Enum.sum(enum)
+
+# Before
+string |> String.to_charlist() |> Enum.reduce(0, &(&1 + &2))
+# Styled
+string |> String.to_charlist() |> Enum.sum()
+```
+
 ### `Timex.now/0` ->` DateTime.utc_now/0` and `Timex.today/0` -> `Date.utc_today/0`
 
 Timex certainly has its uses, but knowing what stdlib date/time struct is returned by Timex is a bit difficult.

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -325,6 +325,38 @@ defmodule Quokka.Style.SingleNode do
   defp style({:++, _, [{{:., _, [{_, _, [:Enum]}, :reverse]} = reverse, r_meta, [lhs]}, rhs]}),
     do: {reverse, r_meta, [lhs, rhs]}
 
+  # `Enum.reduce(enum, 0, fn x, acc -> x + acc end)` => `Enum.sum(enum)`
+  defp style({{:., dm, [{:__aliases__, am, [:Enum]}, :reduce]}, m, [enum, {:__block__, _, [0]}, reducer]} = node) do
+    if Quokka.Config.inefficient_function_rewrites?() and sum_reducer?(reducer),
+      do: {{:., dm, [{:__aliases__, am, [:Enum]}, :sum]}, m, [enum]},
+      else: node
+  end
+
+  # `Enum.reduce(enum, fn x, acc -> x + acc end)` => `Enum.sum(enum)`
+  # Enum.reduce/2 uses the first element as the accumulator; summing the rest is
+  # equivalent to summing the whole enum.
+  defp style({{:., dm, [{:__aliases__, am, [:Enum]}, :reduce]}, m, [enum, reducer]} = node) do
+    if Quokka.Config.inefficient_function_rewrites?() and sum_reducer?(reducer),
+      do: {{:., dm, [{:__aliases__, am, [:Enum]}, :sum]}, m, [enum]},
+      else: node
+  end
+
+  # `enum |> Enum.reduce(0, fn x, acc -> x + acc end)` => `enum |> Enum.sum()`
+  defp style(
+         {:|>, pm, [lhs, {{:., dm, [{:__aliases__, am, [:Enum]}, :reduce]}, m, [{:__block__, _, [0]}, reducer]}]} = node
+       ) do
+    if Quokka.Config.inefficient_function_rewrites?() and sum_reducer?(reducer),
+      do: {:|>, pm, [lhs, {{:., dm, [{:__aliases__, am, [:Enum]}, :sum]}, m, []}]},
+      else: node
+  end
+
+  # `enum |> Enum.reduce(fn x, acc -> x + acc end)` => `enum |> Enum.sum()`
+  defp style({:|>, pm, [lhs, {{:., dm, [{:__aliases__, am, [:Enum]}, :reduce]}, m, [reducer]}]} = node) do
+    if Quokka.Config.inefficient_function_rewrites?() and sum_reducer?(reducer),
+      do: {:|>, pm, [lhs, {{:., dm, [{:__aliases__, am, [:Enum]}, :sum]}, m, []}]},
+      else: node
+  end
+
   @literal_zero_pattern quote do: {:__block__, _, [0]}
   @enum_count_pattern quote do: {{:., var!(m), [{_, _, [:Enum]}, :count]}, _, [var!(enum)]}
   @enum_count_with_fn_pattern quote do: {{:., var!(m), [{_, _, [:Enum]}, :count]}, _, [var!(enum), var!(func)]}
@@ -574,6 +606,24 @@ defmodule Quokka.Style.SingleNode do
   # Check if the AST represents a pattern match (assignment)
   defp is_pattern_match?({:=, _, _}), do: true
   defp is_pattern_match?(_), do: false
+
+  # True when the reducer function just sums its two arguments (in either order).
+  # Matches `fn a, b -> a + b end`, `fn a, b -> b + a end`, `&(&1 + &2)`, `&(&2 + &1)`,
+  # `&+/2`, and `&Kernel.+/2`.
+  defp sum_reducer?({:fn, _, [{:->, _, [[{a, _, ca}, {b, _, cb}], {:+, _, [{x, _, cx}, {y, _, cy}]}]}]})
+       when is_atom(a) and is_atom(b) and is_atom(x) and is_atom(y) and a != :_ and b != :_ and a != b do
+    ({a, ca} == {x, cx} and {b, cb} == {y, cy}) or ({a, ca} == {y, cy} and {b, cb} == {x, cx})
+  end
+
+  defp sum_reducer?({:&, _, [{:+, _, [{:&, _, [n1]}, {:&, _, [n2]}]}]}) when is_integer(n1) and is_integer(n2),
+    do: {n1, n2} in [{1, 2}, {2, 1}]
+
+  defp sum_reducer?({:&, _, [{:/, _, [{:+, _, nil}, {:__block__, _, [2]}]}]}), do: true
+
+  defp sum_reducer?({:&, _, [{:/, _, [{{:., _, [{:__aliases__, _, [:Kernel]}, :+]}, _, []}, {:__block__, _, [2]}]}]}),
+    do: true
+
+  defp sum_reducer?(_), do: false
 
   defp replace_into({:., dm, [{_, am, _} = enum, _]}, collectable, rest) do
     case Quokka.Config.inefficient_function_rewrites?() and collectable do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1351,4 +1351,128 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("& &1.(&2)")
     end
   end
+
+  describe "Enum.reduce summing => Enum.sum" do
+    test "rewrites summing reducer with fn x, acc -> x + acc end" do
+      assert_style(
+        "Enum.reduce(enum, 0, fn x, acc -> x + acc end)",
+        "Enum.sum(enum)"
+      )
+    end
+
+    test "rewrites summing reducer with operands in either order" do
+      assert_style(
+        "Enum.reduce(enum, 0, fn x, acc -> acc + x end)",
+        "Enum.sum(enum)"
+      )
+    end
+
+    test "rewrites &(&1 + &2) capture" do
+      assert_style("Enum.reduce(enum, 0, &(&1 + &2))", "Enum.sum(enum)")
+      assert_style("Enum.reduce(enum, 0, &(&2 + &1))", "Enum.sum(enum)")
+    end
+
+    test "rewrites &+/2 and &Kernel.+/2 captures" do
+      assert_style("Enum.reduce(enum, 0, &+/2)", "Enum.sum(enum)")
+      assert_style("Enum.reduce(enum, 0, &Kernel.+/2)", "Enum.sum(enum)")
+    end
+
+    test "rewrites piped form" do
+      assert_style(
+        """
+        string
+        |> String.to_charlist()
+        |> Enum.reduce(0, fn x, acc -> x + acc end)
+        """,
+        """
+        string
+        |> String.to_charlist()
+        |> Enum.sum()
+        """
+      )
+    end
+
+    test "rewrites single-pipe form" do
+      assert_style(
+        "enum |> Enum.reduce(0, fn x, acc -> x + acc end)",
+        "enum |> Enum.sum()"
+      )
+    end
+
+    test "rewrites piped capture forms" do
+      assert_style("enum |> Enum.reduce(0, &(&1 + &2))", "enum |> Enum.sum()")
+      assert_style("enum |> Enum.reduce(0, &+/2)", "enum |> Enum.sum()")
+    end
+
+    test "rewrites Enum.reduce/2 summing form" do
+      assert_style(
+        "Enum.reduce(enum, fn x, acc -> x + acc end)",
+        "Enum.sum(enum)"
+      )
+
+      assert_style("Enum.reduce(enum, &+/2)", "Enum.sum(enum)")
+      assert_style("Enum.reduce(enum, &(&1 + &2))", "Enum.sum(enum)")
+
+      assert_style(
+        "enum |> Enum.reduce(fn x, acc -> x + acc end)",
+        "enum |> Enum.sum()"
+      )
+
+      assert_style(
+        """
+        string
+        |> String.to_charlist()
+        |> Enum.reduce(fn x, acc -> x + acc end)
+        """,
+        """
+        string
+        |> String.to_charlist()
+        |> Enum.sum()
+        """
+      )
+    end
+
+    test "does not rewrite when accumulator is not zero" do
+      assert_style("Enum.reduce(enum, 1, fn x, acc -> x + acc end)")
+      assert_style("Enum.reduce(enum, initial, fn x, acc -> x + acc end)")
+    end
+
+    test "does not rewrite when accumulator is 0.0 (preserves float type)" do
+      assert_style("Enum.reduce(enum, 0.0, fn x, acc -> x + acc end)")
+    end
+
+    test "does not rewrite when body is not a simple sum of the two args" do
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x - acc end)")
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x * acc end)")
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x + acc + 1 end)")
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x + 1 end)")
+      assert_style("Enum.reduce(enum, 0, fn x, _acc -> x end)")
+      assert_style("Enum.reduce(enum, 0, fn x, _acc -> x + x end)")
+      assert_style("Enum.reduce(enum, fn x, acc -> x - acc end)")
+      assert_style("Enum.reduce(enum, fn x, acc -> x * acc end)")
+      assert_style("Enum.reduce(enum, fn x, acc -> x + acc + 1 end)")
+      assert_style("Enum.reduce(enum, fn x, acc -> x + 1 end)")
+      assert_style("Enum.reduce(enum, fn x, _acc -> x end)")
+      assert_style("Enum.reduce(enum, fn x, _acc -> x + x end)")
+    end
+
+    test "does not rewrite non-Enum modules" do
+      assert_style("MyMod.reduce(enum, 0, fn x, acc -> x + acc end)")
+    end
+
+    test "does not rewrite when capture indices are wrong" do
+      assert_style("Enum.reduce(enum, 0, &(&1 + &1))")
+      assert_style("Enum.reduce(enum, 0, &(&1 + &3))")
+    end
+
+    test "respects inefficient_functions config" do
+      stub(Quokka.Config, :inefficient_function_rewrites?, fn -> false end)
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x + acc end)")
+      assert_style("enum |> Enum.reduce(0, &+/2)")
+
+      stub(Quokka.Config, :inefficient_function_rewrites?, fn -> true end)
+      assert_style("Enum.reduce(enum, 0, fn x, acc -> x + acc end)", "Enum.sum(enum)")
+      assert_style("enum |> Enum.reduce(0, &+/2)", "enum |> Enum.sum()")
+    end
+  end
 end


### PR DESCRIPTION
When the body of the function provided to `Enum.reduce/{2,3}` performs a simple sum, this rewrites it to use the much more readable `Enum.sum/1`. If the enumerable is ever a range, this can be a massive performance improvement: `Enum.sum/1` internally will jump to the closed-form solution rather than adding (say) a million numbers together.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [N/A] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
