### PR TITLE
Fix Enum.reduce/3 in a pipe being rewritten to nonexistent Enum.sum/2

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -172,7 +172,7 @@ Enum.reverse(baz, bop)
 
 ### `Enum.reduce` summing -> `Enum.sum`
 
-Quokka rewrites `Enum.reduce/2,3` calls whose reducer simply adds the two arguments to `Enum.sum/1`. This covers anonymous functions (with operands in either order), `&(&1 + &2)` captures, and `&+/2` / `&Kernel.+/2` captures. For `Enum.reduce/3`, the accumulator must be the literal integer `0` (so `0.0` is left alone to preserve float typing on empty enums).
+Quokka rewrites `Enum.reduce/2,3` calls whose reducer simply adds the two arguments to `Enum.sum/1`. This covers anonymous functions (with operands in either order), `&(&1 + &2)` captures, and `&+/2` / `&Kernel.+/2` captures. For `Enum.reduce/3`, the accumulator must be the literal integer `0` (so `0.0` is left alone to preserve float typing on empty enums). This holds in pipe position too: `enum |> Enum.reduce(acc, &+/2)` with a non-zero accumulator is left unchanged.
 
 ```elixir
 # Before

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -43,6 +43,21 @@ defmodule Quokka.Style.SingleNode do
   def run({{:|>, _, [_, {{:., _, [{:__aliases__, _, [:Timex]}, :today]}, _, []}]}, _} = zipper, ctx),
     do: {:skip, zipper, ctx}
 
+  # A pipe-fed `Enum.reduce/3` (`lhs |> Enum.reduce(acc, reducer)`) reaches node
+  # styling as its inner `Enum.reduce(acc, reducer)`, which is shaped exactly
+  # like `Enum.reduce/2`. The reduce/2 => Enum.sum rewrite would treat the
+  # accumulator as the enumerable and emit `Enum.sum(acc)`; re-piped that is
+  # `Enum.sum/2`, which exists in no Elixir version. The zero-accumulator pure
+  # sum is handled at the pipe node itself (`|> Enum.reduce(0, &+/2)` =>
+  # `|> Enum.sum()`); here we only decline the rewrite for the genuine reduce/3
+  # form, while still traversing so the rest of the tree is styled.
+  def run({{{:., _, [{:__aliases__, _, [:Enum]}, :reduce]}, _, [_, _]} = reduce, meta} = zipper, ctx) do
+    case Zipper.up(zipper) do
+      {{:|>, _, [_, ^reduce]}, _} -> {:cont, zipper, ctx}
+      _ -> {:cont, {style(reduce), meta}, ctx}
+    end
+  end
+
   # Skip expensive empty enum check rewrites when inside guard clauses
   def run({node, meta} = zipper, ctx) when elem(node, 0) in [:>, :<, :==, :===, :!=] do
     if in_guard?(zipper) do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1404,6 +1404,24 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("enum |> Enum.reduce(0, &+/2)", "enum |> Enum.sum()")
     end
 
+    test "does not rewrite a pipe-fed non-zero accumulator into Enum.sum/2" do
+      # The inner node is `Enum.reduce(<acc>, &+/2)`: its first argument is the
+      # accumulator (the enumerable is piped from the left), not the enumerable.
+      # Rewriting would emit `enum |> Enum.sum(<acc>)` => `Enum.sum/2`, which
+      # exists in no Elixir version. Only the zero-accumulator pure sum is
+      # rewritten (handled at the pipe node, see below); every other initial
+      # accumulator must be left intact.
+      assert_style("enum |> Enum.reduce(0.0, &+/2)")
+      assert_style("enum |> Enum.reduce(1, &+/2)")
+      assert_style("enum |> Enum.reduce(acc, &+/2)")
+      assert_style("enum |> Enum.reduce(%{}, fn x, acc -> x + acc end)")
+      # lhs of the pipe is still traversed/untouched (subtree not skipped).
+      assert_style("Enum.map(c, & &1.v) |> Enum.reduce(0.0, &+/2)")
+
+      # The zero-accumulator pure-sum pipe is still rewritten.
+      assert_style("enum |> Enum.reduce(0, &+/2)", "enum |> Enum.sum()")
+    end
+
     test "rewrites Enum.reduce/2 summing form" do
       assert_style(
         "Enum.reduce(enum, fn x, acc -> x + acc end)",


### PR DESCRIPTION
## Description

The `Enum.reduce` → `Enum.sum` rewrite corrupts code when an `Enum.reduce/3` with a non-zero / non-integer accumulator is the right-hand side of a pipe:

```elixir
total = values |> Enum.reduce(0.0, &+/2)
# 2.13.0 rewrites this to:
total = values |> Enum.sum(0.0)   # Enum.sum/2 — exists in no Elixir version
```

`Enum.sum/2` does not exist in any Elixir release (verified on 1.19.5 and 1.20.0-rc.5: `UndefinedFunctionError`), so working code becomes a runtime crash. Triggers for any non-zero/non-integer accumulator (`0.0`, `1`, a variable, `%{}`, …).

**Root cause:** `lhs |> Enum.reduce(acc, reducer)` reaches node styling as its inner `Enum.reduce(acc, reducer)`, which is structurally identical to a real `Enum.reduce/2`. The reduce/2 → `Enum.sum/1` clause binds the accumulator as the enumerable and emits `Enum.sum(acc)`; re-piped that is `Enum.sum/2`. This already contradicts `docs/styles.md` ("the accumulator must be the literal integer `0`, so `0.0` is left alone to preserve float typing on empty enums"). Every existing sum-rewrite test uses an integer `0` accumulator, so the pipe-fed path was untested.

**Fix:** add a `SingleNode.run/2` clause (same idiom as the existing `Timex` pipe-skip clauses) that, when an `Enum.reduce/2`-shaped node is the RHS of a pipe (a genuine `reduce/3`), declines the sum rewrite while still traversing so the rest of the tree (including the pipe LHS) is styled. The valid integer-`0` pure sum is unaffected — it is handled at the pipe node itself before traversal descends to the inner node.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes