### PR TITLE
Scope autosort map comment collection to the map's own lines (fixes #161)

### DIFF
--- a/lib/style/autosort.ex
+++ b/lib/style/autosort.ex
@@ -102,8 +102,13 @@ defmodule Quokka.Style.Autosort do
   defp keyword_pairs?(list), do: Enum.all?(list, &match?({{_, _, _}, _}, &1))
 
   defp sort_keyword_list_with_comments(pairs, comments, map_open_line) do
+    # Seed prev_last_line with the map's opening line so the first pair only
+    # claims comments physically inside the map. With a nil seed the first
+    # pair's lower bound is unbounded and it steals every comment earlier in
+    # the module (e.g. a `# credo:disable-for-next-line` in another function),
+    # then sorting rewrites those comments' lines. See emkguts/quokka#161.
     {groups, {comments, _last_line}} =
-      Enum.map_reduce(pairs, {comments, nil}, fn pair, {comments_acc, prev_last_line} ->
+      Enum.map_reduce(pairs, {comments, map_open_line}, fn pair, {comments_acc, prev_last_line} ->
         line = Style.meta(pair)[:line]
         last_line = Style.max_line(pair)
         {mine, rest} = pair_comments_for_keyword(comments_acc, prev_last_line, line, last_line)

--- a/test/style/autosort_test.exs
+++ b/test/style/autosort_test.exs
@@ -12,6 +12,60 @@ defmodule Quokka.Style.AutosortTest do
   @moduledoc false
   use Quokka.StyleCase, async: true
 
+  describe "comment scoping" do
+    test "sorting a map does not steal comments from earlier in the module" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+
+      assert_style(
+        """
+        defmodule Repro do
+          def get!(account_id, preload) do
+            account_id
+            |> load()
+            # credo:disable-for-next-line Some.Check
+            |> preload(preload)
+            # trailing comment belonging to the case below
+            case account_id do
+              nil -> :error
+              _ -> :ok
+            end
+          end
+
+          defp analytics(query) do
+            select(query, [d], %{
+              total: d.a,
+              currency_code: d.c
+            })
+          end
+        end
+        """,
+        """
+        defmodule Repro do
+          def get!(account_id, preload) do
+            account_id
+            |> load()
+            # credo:disable-for-next-line Some.Check
+            |> preload(preload)
+
+            # trailing comment belonging to the case below
+            case account_id do
+              nil -> :error
+              _ -> :ok
+            end
+          end
+
+          defp analytics(query) do
+            select(query, [d], %{
+              currency_code: d.c,
+              total: d.a
+            })
+          end
+        end
+        """
+      )
+    end
+  end
+
   describe "config autosort" do
     test "autosorts schema fields" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:schema] end)


### PR DESCRIPTION
## Description

Fixes #161.

When `:autosort` sorts a multi-line keyword/map literal, `sort_keyword_list_with_comments` seeded the `Enum.map_reduce` accumulator's `prev_last_line` with `nil`. For the first pair, `pair_comments_for_keyword` then degenerates to `comment_line <= last_line` with **no lower bound**, so it claims every comment earlier in the module — including a `# credo:disable-for-next-line` (or any comment) in an unrelated, earlier function. `sort_groups_sequentially` then rewrites those stolen comments' lines, detaching the directive from the code it suppressed and silently breaking the suppression on a routine `mix format`.

Seed `prev_last_line` with the map's opening line so the first pair only claims comments physically inside the map. The existing `is_nil(prev_last_line)` guard is kept as a defensive fallback.

Repro (from #161), `quokka: [autosort: [:map]]`, before this change:

```elixir
account_id
|> load()
# credo:disable-for-next-line Some.Check
|> preload(preload)
# trailing comment belonging to the case below
case account_id do
```

became

```elixir
account_id
|> load()
# credo:disable-for-next-line Some.Check
# trailing comment belonging to the case below
|> preload(preload)

case account_id do
```

(the `# credo:disable-for-next-line` no longer precedes its target). With this change the comments stay put. Verified both in the added unit test and end-to-end via `mix format` on the original real-world reproducer.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] If there are changes to installation, usage, or project overview, I have updated README.md
- [ ] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes