### PR TITLE
Autosort: a sorted key's leading comment is stranded at the map top

### DIFF
--- a/lib/style/autosort.ex
+++ b/lib/style/autosort.ex
@@ -167,12 +167,12 @@ defmodule Quokka.Style.Autosort do
   defp place_pair_with_comments(pair, pair_comments, line) do
     pair_comments = Enum.sort_by(pair_comments, & &1.line)
 
-    line =
-      case pair_comments do
-        [%{line: comment_line} | _] -> min(line, comment_line)
-        _ -> line
-      end
-
+    # Place comments at the sequential cursor (where this pair lands after
+    # sorting), not at min(cursor, comment's original line). Clamping to the
+    # comment's stale pre-sort line strands a moved key's leading comment at
+    # the map top instead of travelling with the key. In the not-moved case
+    # the cursor is already <= the comment line, so dropping the clamp is a
+    # no-op there. See emkguts/quokka#161 follow-up.
     {placed_comments, line} =
       Enum.map_reduce(pair_comments, line, fn comment, line ->
         {%{comment | line: line, previous_eol_count: 1}, line + 1}

--- a/test/style/autosort_test.exs
+++ b/test/style/autosort_test.exs
@@ -12,6 +12,49 @@ defmodule Quokka.Style.AutosortTest do
   @moduledoc false
   use Quokka.StyleCase, async: true
 
+  describe "leading comments travel with their key when sorted" do
+    test "a moved key's leading comment is not stranded at the map top" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+
+      assert_style(
+        """
+        defmodule M do
+          def cfg do
+            %{
+              # zeta section
+              zeta: 1,
+              # alpha section
+              alpha: 2,
+              # mid comment
+              mid: 3
+              # trailing comment after last key
+            }
+          end
+
+          def other, do: :ok
+        end
+        """,
+        """
+        defmodule M do
+          def cfg() do
+            %{
+              # alpha section
+              alpha: 2,
+              # mid comment
+              mid: 3,
+              # zeta section
+              zeta: 1
+              # trailing comment after last key
+            }
+          end
+
+          def other(), do: :ok
+        end
+        """
+      )
+    end
+  end
+
   describe "comment scoping" do
     test "sorting a map does not steal comments from earlier in the module" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)


### PR DESCRIPTION
## Description

Follow-up to #161/#162. When autosort moves a key to a later position, `place_pair_with_comments` clamped the placement line to `min(cursor, first_comment_original_line)`. The first key's leading comment has a small original line number, so the clamp snapped it back to the **top of the map**, stranding it away from the key it belongs to:

```elixir
# autosort: [:map], before:
%{
  # zeta section
  zeta: 1,
  # alpha section
  alpha: 2
}

# 2.13.1 (buggy) — "# zeta section" stranded at top, no longer with zeta:
%{
  # zeta section
  # alpha section
  alpha: 2,
  zeta: 1
}

# with this change — comment travels with its key:
%{
  # alpha section
  alpha: 2,
  # zeta section
  zeta: 1
}
```

Fix: place a sorted pair's comments at the sequential cursor (where the pair lands after sorting) instead of clamping to the comment's stale pre-sort line. In the not-moved case the cursor is already `<=` the comment's line, so removing the clamp is a no-op there (no behavior change for the common path), confirmed by the full suite.

### Scope (important)

This fixes one concrete relocation bug. It does **not** claim to make autosort safe for maps that use *section/grouping* comments (e.g. a large `%{}` translation/config map with `# Group A` / `# Group B` headers): sorting the entries alphabetically inherently disperses such groups, and per-key comment attachment will scatter the headers regardless. That is a design limitation of sorting grouped data, better addressed by *not* enabling autosort on such structures (and/or a separate discussion in #161 about skipping structures containing non-pair comments) — out of scope here.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] If there are changes to installation, usage, or project overview, I have updated README.md
- [ ] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes