### PR TITLE
Autosort: skip commented collections; fix comment order under # quokka:sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+### Fixes
+
+- Config-driven autosort no longer reorders a map, `defstruct`, or schema block that contains comments. This restores the pre-2.13.0 behaviour: in real codebases, a comment inside such a collection typically heads a section of multiple entries, and sorting alphabetically disperses the section, scattering the comment away from the lines it documented. Per-value sorting is still available via `# quokka:sort`, which is unaffected and continues to attach comments to the entry they belong to.
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixes

--- a/docs/autosort.md
+++ b/docs/autosort.md
@@ -4,7 +4,7 @@ Config-driven sorting for maps, `defstruct`s, and Ecto schemas.
 
 ## Autosort vs `# quokka:sort`
 
-Quokka has two complementary ways to sort values. Both use the same sorting implementation and comment rules.
+Quokka has two complementary ways to sort values. Both use the same sorting implementation. They differ in how they handle comments: config autosort skips any entity that contains comments, while `# quokka:sort` always sorts and attaches comments to the entry they belong to.
 
 | | Config autosort | `# quokka:sort` |
 |---|---|---|
@@ -53,27 +53,19 @@ The default schema order is: `[:field, :belongs_to, :has_many, :has_one, :many_t
 
 ## When autosort runs
 
-For each sortable entity (map, `defstruct`, or schema block), autosort **sorts** unless one of these applies:
+For each sortable entity (map, `defstruct`, or schema block), config autosort **sorts** unless one of these applies:
 
 1. **`# quokka:skip-sort`** on the line above the entity — opt out of autosort for that value only.
-2. **Ecto query context** (when `exclude: [:autosort_ecto]` is set) — maps inside detected `from` queries are not sorted. See [Ecto queries](#ecto-queries) below.
+2. **The entity contains comments** — a comment in a map, `defstruct`, or schema block typically heads a human-meaningful section. Sorting the entries alphabetically scatters the section, so config autosort leaves any commented entity untouched. To sort a commented entity, use `# quokka:sort` on the line above it.
+3. **Ecto query context** (when `exclude: [:autosort_ecto]` is set) — maps inside detected `from` queries are not sorted. See [Ecto queries](#ecto-queries) below.
 
 ## Comments
 
-Autosort passes comments through to the formatter so they stay with the code they annotate. The general rule (shared with [`# quokka:sort`](comment_directives.md)) is:
+Config autosort skips any entity containing comments (rule 2 above). For values you do want sorted in spite of comments, opt in per-value with [`# quokka:sort`](comment_directives.md), which still sorts and attaches comments to the entry they belong to:
 
 - A comment on the same lines as an entry, or on the line(s) immediately above it, belongs to that entry.
 - After sorting, comments are placed on lines above the entry they belong to.
 - End-of-line comments (for example `b: 5, # note`) are moved onto their own line above the entry, matching `mix format` behavior.
-
-How that applies depends on what is being autosorted:
-
-| Type | What gets sorted | Comment handling |
-|------|------------------|------------------|
-| **`:map`** | Map keys (and map-update keyword lists) | Each key is sorted with its comments as a group; comments stay above that key after formatting. |
-| **`:defstruct`** (keyword form) | Fields like `defstruct b: 1, a: 2` | Same as maps. |
-| **`:defstruct`** (atom list) | Fields like `defstruct [:c, :b, :a]` | Fields are sorted, then line numbers and comments are adjusted together via the shared comment-ordering logic. |
-| **`:schema`** | `schema`, `typed_schema`, and `embedded_schema` fields | Fields are grouped by type (`:field`, `:has_many`, and so on), sorted within each group, then comments are re-laid-out with the sorted fields. Association macros keep blank lines between groups. |
 
 For values that autosort does not cover (plain lists, sigils, `@type` maps without autosort enabled, and so on), use [`# quokka:sort`](comment_directives.md). That directive uses the same sorting implementation and the same comment association rules.
 
@@ -114,15 +106,15 @@ would yield
 %{a: 1, b: 2, c: 3}
 
 %{
+  c: 3,
   a: 1,
   # this is a weird case
   # and the comment is multiline
-  b: 2,
-  c: 3
+  b: 2
 }
 ```
 
-The plain map is sorted. The `# quokka:skip-sort` map is left unchanged. See [Comments](#comments) for how comments move with their keys.
+The plain map is sorted. The `# quokka:skip-sort` map is left unchanged. The commented map is left unchanged because config autosort skips any entity containing comments (see [When autosort runs](#when-autosort-runs)). To sort a commented value explicitly, use [`# quokka:sort`](comment_directives.md).
 
 ## Defstruct examples
 

--- a/docs/comment_directives.md
+++ b/docs/comment_directives.md
@@ -92,7 +92,13 @@ a_var =
 
 ### Comments while sorting
 
-`# quokka:sort` uses the same sorting code as [autosort](autosort.md) and follows the same comment rules: comments stay with the entry they belonged to (on lines above it after formatting). See [Autosort → Comments](autosort.md#comments) for how that works for maps, defstructs, and schemas under config autosort.
+`# quokka:sort` uses the same sorting code as [autosort](autosort.md) but, unlike config autosort, still sorts a value that contains comments. Comments stay with the entry they belonged to:
+
+- A comment on the same lines as an entry, or on the line(s) immediately above it, belongs to that entry.
+- After sorting, comments are placed on lines above the entry they belong to.
+- End-of-line comments (for example `b: 5, # note`) are moved onto their own line above the entry, matching `mix format` behaviour.
+
+Config autosort, by contrast, skips any entity that contains comments. See [Autosort → When autosort runs](autosort.md#when-autosort-runs) for that rule.
 
 For `# quokka:skip-sort` and config options, see [Autosort](autosort.md).
 

--- a/lib/style/autosort.ex
+++ b/lib/style/autosort.ex
@@ -29,12 +29,13 @@ defmodule Quokka.Style.Autosort do
       should_skip = node_line && MapSet.member?(skip_sort_lines, node_line)
       is_sortable = get_node_type(node) in autosort_types
       is_query = ecto_from_query?(node)
+      has_comments = has_comments_inside?(node, ctx.comments)
 
       cond do
         is_query and Quokka.Config.autosort_exclude_ecto?() ->
           {:skip, zipper, ctx}
 
-        should_skip || !is_sortable ->
+        should_skip || has_comments || !is_sortable ->
           {:cont, zipper, ctx}
 
         true ->
@@ -58,6 +59,20 @@ defmodule Quokka.Style.Autosort do
       _ ->
         false
     end
+  end
+
+  # Config-driven autosort must not reorder a collection that contains
+  # comments. A comment in a map/struct typically heads a human-meaningful
+  # section of the collection; sorting the entries alphabetically disperses
+  # the section and the header ends up attached to whatever key now follows
+  # it. This restores the pre-2.13.0 behaviour. Users who really want a
+  # commented collection sorted can opt in per-collection with `# quokka:sort`,
+  # which is handled separately and is not affected by this guard.
+  defp has_comments_inside?(node, comments) do
+    start_line = Style.meta(node)[:line] || 0
+    end_line = Style.max_line(node) || start_line
+
+    end_line > start_line && Enum.any?(comments, &(&1.line > start_line && &1.line < end_line))
   end
 
   defp collect_skip_sort_lines(comments) do
@@ -123,9 +138,10 @@ defmodule Quokka.Style.Autosort do
       pairs = Enum.map(groups, &elem(&1, 0))
 
       comments =
-        Enum.flat_map(groups, fn {_, pair_comments} ->
-          Enum.sort_by(pair_comments, & &1.line)
-        end) ++ comments
+        groups
+        |> Enum.flat_map(fn {_, pair_comments} -> pair_comments end)
+        |> Kernel.++(comments)
+        |> Enum.sort_by(& &1.line)
 
       {pairs, comments}
     end
@@ -161,7 +177,13 @@ defmodule Quokka.Style.Autosort do
         {[placed_pair | pairs], placed_comments ++ comments, next_line}
       end)
 
-    {Enum.reverse(pairs), comments}
+    # The formatter emits comments in list order, not by `.line`, so we must
+    # return them sorted by line. Without this, multiple per-pair leading
+    # comments and the orphan list end up reversed and clustered together
+    # above one key after sorting (e.g. `# quokka:sort` on a map with
+    # several internal `# group ...` comments). Closely related to
+    # emkguts/quokka#161/#163.
+    {Enum.reverse(pairs), Enum.sort_by(comments, & &1.line)}
   end
 
   defp place_pair_with_comments(pair, pair_comments, line) do

--- a/test/style/autosort_test.exs
+++ b/test/style/autosort_test.exs
@@ -12,49 +12,6 @@ defmodule Quokka.Style.AutosortTest do
   @moduledoc false
   use Quokka.StyleCase, async: true
 
-  describe "leading comments travel with their key when sorted" do
-    test "a moved key's leading comment is not stranded at the map top" do
-      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
-
-      assert_style(
-        """
-        defmodule M do
-          def cfg do
-            %{
-              # zeta section
-              zeta: 1,
-              # alpha section
-              alpha: 2,
-              # mid comment
-              mid: 3
-              # trailing comment after last key
-            }
-          end
-
-          def other, do: :ok
-        end
-        """,
-        """
-        defmodule M do
-          def cfg() do
-            %{
-              # alpha section
-              alpha: 2,
-              # mid comment
-              mid: 3,
-              # zeta section
-              zeta: 1
-              # trailing comment after last key
-            }
-          end
-
-          def other(), do: :ok
-        end
-        """
-      )
-    end
-  end
-
   describe "comment scoping" do
     test "sorting a map does not steal comments from earlier in the module" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
@@ -686,34 +643,25 @@ defmodule Quokka.Style.AutosortTest do
       """)
     end
 
-    test "autosorts maps and keeps comments above their key" do
+    test "does not autosort a map that has block comments inside it" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
 
-      assert_style(
-        """
-        %{
-          c: 3,
-          a: 1,
-          # this is a weird case
-          # and the comment is multiline
-          b: 2
-        }
-        """,
-        """
-        %{
-          a: 1,
-          # this is a weird case
-          # and the comment is multiline
-          b: 2,
-          c: 3
-        }
-        """
-      )
+      assert_style("""
+      %{
+        c: 3,
+        a: 1,
+        # this is a weird case
+        # and the comment is multiline
+        b: 2
+      }
+      """)
     end
 
-    test "autosorts maps and moves end-of-line comments above the key like mix format" do
+    test "does not autosort a map that has an end-of-line comment inside it" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
 
+      # mix format hoists the trailing comment to its own line; the key order
+      # is unchanged because autosort skips commented maps.
       assert_style(
         """
         %{
@@ -725,17 +673,17 @@ defmodule Quokka.Style.AutosortTest do
         """,
         """
         %{
-          a: 1,
+          d: 4,
           # this is a special case
           b: 5,
           c: 3,
-          d: 4
+          a: 1
         }
         """
       )
     end
 
-    test "autosorts maps with block and end-of-line comments on the same key" do
+    test "does not autosort a map that has both block and end-of-line comments inside it" do
       Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
 
       assert_style(
@@ -749,14 +697,78 @@ defmodule Quokka.Style.AutosortTest do
         """,
         """
         %{
-          a: 1,
+          d: 4,
           # block comment above b
           # inline on b
           b: 5,
-          d: 4
+          a: 1
         }
         """
       )
+    end
+
+    test "does not autosort a map containing a section comment heading multiple keys" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:map] end)
+
+      assert_style("""
+      %{
+        # group one
+        "alpha" => 1,
+        "beta" => 2,
+        "gamma" => 3,
+        # group two
+        "delta" => 4,
+        "epsilon" => 5
+      }
+      """)
+    end
+
+    test "does not autosort a defstruct that has a comment inside it" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:defstruct] end)
+
+      assert_style("""
+      defmodule M do
+        defstruct [
+          # primary keys
+          :id,
+          :ref,
+          # metadata
+          :created_at,
+          :updated_at
+        ]
+      end
+      """)
+    end
+
+    test "does not autosort a defstruct (keyword form) that has a comment inside it" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:defstruct] end)
+
+      assert_style("""
+      defmodule M do
+        defstruct c: 1,
+                  # explain b
+                  b: 2,
+                  a: 3
+      end
+      """)
+    end
+
+    test "does not autosort a schema that has a comment inside its block" do
+      Mimic.stub(Quokka.Config, :autosort, fn -> [:schema] end)
+
+      assert_style("""
+      defmodule MySchema do
+        use Ecto.Schema
+
+        schema "my_schema" do
+          # identifying fields
+          field(:name, :string)
+          field(:age, :integer)
+          # contact
+          field(:email, :string)
+        end
+      end
+      """)
     end
 
     test "autosorts module attributes" do

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -141,6 +141,33 @@ defmodule Quokka.Style.CommentDirectivesTest do
       )
     end
 
+    test "moved keys' leading comments travel with each key, directive is preserved" do
+      assert_style(
+        """
+        # quokka:sort
+        %{
+          # zeta section
+          zeta: 1,
+          # alpha section
+          alpha: 2,
+          # mid comment
+          mid: 3
+        }
+        """,
+        """
+        # quokka:sort
+        %{
+          # alpha section
+          alpha: 2,
+          # mid comment
+          mid: 3,
+          # zeta section
+          zeta: 1
+        }
+        """
+      )
+    end
+
     test "inside keywords" do
       assert_style(
         """


### PR DESCRIPTION
## Summary

Two related changes in autosort comment handling:

1. Restore the pre-2.13.0 `has_comments` skip for config-driven autosort.
2. Keep returned comments sorted by `.line` so `# quokka:sort` remains stable and idempotent on commented collections.

## Changes

Before the #155/#158 overhaul, `Autosort.run/2` skipped config-driven autosort when a sortable collection contained comments:

```elixir
should_skip || has_comments || !is_sortable -> {:cont, ...}
```

That meant `autosort: [:map, :defstruct, :schema]` did not reorder commented maps, defstructs, or schema blocks. The overhaul removed that guard and instead sorted commented collections while trying to keep comments attached to their keys.

That works for per-key comments, but not for standalone section comments heading a run of entries. Sorting alphabetically disperses the run, and the section header ends up next to whichever key now follows it. The section-header and per-key-comment cases are structurally identical at the AST/comment-layout level, so there is no reliable heuristic that separates them.

This PR adds `has_comments_inside?/2` back, byte-equivalent to the pre-overhaul predicate at `c73b2b7~1`, and includes it in the `Autosort.run/2` skip condition. `# quokka:sort` is handled separately by `CommentDirectives` via `Autosort.sort/2`, so users can still opt in per value when they want a commented collection sorted.

This PR also sorts the comments returned by `sort_keyword_list_with_comments/3` by `.line`. `sort_groups_sequentially/3` prepends placed comments while iterating, and the no-reorder branch could also return comments out of order. Since the formatter emits comments in list order, that could reverse and cluster per-key comments, and on a second pass pull `# quokka:sort` inside the map. Sorting by line keeps leading comments with their keys and preserves idempotence.

## Tests

- Updated the three existing commented-map autosort tests to assert the restored skip behavior.
- Added skip-regression tests for section comments, `defstruct` atom-list form, `defstruct` keyword form, and schema blocks.
- Added a `# quokka:sort` regression test for multiple per-key leading comments, directive preservation, and idempotence.

Full suite: 484 tests, 0 failures.

## Docs

Updated `docs/autosort.md`, `docs/comment_directives.md`, and `CHANGELOG.md`.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes