### PR TITLE
fix (deprecations): Avoid rewriting negative uses of `:timer.hours/1`, `:timer.minutes/1`, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+### Fixes
+
+- Avoid `:deprecations` rules rewriting negative uses of `:timer.[units]/1` (`:timer.hours/1`, `:timer.minutes/1`, etc.). If there are negatives in literal values passed to `:timer.[units]/1`, we shouldn't rewrite it to use `to_timeout/1` since doing so will raise a runtime error (by definition, a timeout must be non-negative).
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixes

--- a/lib/style/deprecations.ex
+++ b/lib/style/deprecations.ex
@@ -71,7 +71,8 @@ defmodule Quokka.Style.Deprecations do
 
   for {erl, ex} <- [hours: :hour, minutes: :minute, seconds: :second] do
     defp style({{:., _, [{:__block__, _, [:timer]}, unquote(erl)]}, fm, [x]} = node) do
-      if Version.match?(Quokka.Config.elixir_version(), ">= 1.17.0-dev") do
+      # `to_timeout/1` raises on negative durations, so leave those `:timer` calls untouched
+      if Version.match?(Quokka.Config.elixir_version(), ">= 1.17.0-dev") and not contains_negative?(x) do
         {:to_timeout, fm, [[{{:__block__, [format: :keyword, line: fm[:line]], [unquote(ex)]}, x}]]}
       else
         node
@@ -121,6 +122,13 @@ defmodule Quokka.Style.Deprecations do
 
   defp rewrite_range_match({:.., dm, [first, {_, m, _} = last]}), do: {:..//, dm, [first, last, {:_, m, nil}]}
   defp rewrite_range_match(x), do: x
+
+  # Detects a unary minus (negative literal) anywhere in the AST
+  defp contains_negative?({:-, _, [_single]}), do: true
+  defp contains_negative?({_, _, args}) when is_list(args), do: Enum.any?(args, &contains_negative?/1)
+  defp contains_negative?({left, right}), do: contains_negative?(left) or contains_negative?(right)
+  defp contains_negative?(list) when is_list(list), do: Enum.any?(list, &contains_negative?/1)
+  defp contains_negative?(_), do: false
 
   defp add_step_to_date_range?(first, last) do
     with {:ok, f} <- extract_date_value(first),

--- a/test/style/deprecations_test.exs
+++ b/test/style/deprecations_test.exs
@@ -168,6 +168,13 @@ defmodule Quokka.Style.DeprecationsTest do
       assert_style "a |> x() |> :timer.seconds()"
     end
 
+    test ":timer.x does not get rewritten when it includes negatives" do
+      assert_style ":timer.minutes(-60)", ":timer.minutes(-60)"
+      assert_style ":timer.hours(7 * -24)", ":timer.hours(7 * -24)"
+      assert_style ":timer.hours(hour_count * -24)", ":timer.hours(hour_count * -24)"
+      assert_style ":timer.hours(24 * -days)", ":timer.hours(24 * -days)"
+    end
+
     test "combined with :timer.x deprecation rewrite" do
       assert_style ":timer.minutes(60 * 4)", "to_timeout(hour: 4)"
     end


### PR DESCRIPTION
This fixes an issue we had at Jump when we enabled the `:deprecations` rewrites, where we had uses of the `:timer.[units]/1` functions that passed negative values. When those get rewritten to use `to_timeout/1`, they raise a runtime error because a timeout is defined to be non-negative.

## PR Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
