### PR TITLE
feat (pipes): Fold Kernel operators back into an inline expression where it results in a readability improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 ### Improvements
 
 - Fold a `Kernel` operator that starts a pipe back into an inline expression (e.g. `foo |> Kernel.||(bar) |> Enum.map(...)` becomes `(foo || bar) |> Enum.map(...)`). This applies to all `Kernel` infix/unary operators (`++`, `||`, `<>`, `/`, `-`, etc.), but only when the operator is the very first function in the pipe.
+- Fold a non-piped `Kernel` operator call back into an inline expression (e.g. `Kernel./(total, size)` becomes `total / size`, `Kernel.-(x)` becomes `-x`). This applies to all `Kernel` infix/unary operators, while operators in pipe position are left to the pipe-folding rewrite above.
 
 ## [2.13.1] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+### Improvements
+
+- Fold a `Kernel` operator that starts a pipe back into an inline expression (e.g. `foo |> Kernel.||(bar) |> Enum.map(...)` becomes `(foo || bar) |> Enum.map(...)`). This applies to all `Kernel` infix/unary operators (`++`, `||`, `<>`, `/`, `-`, etc.), but only when the operator is the very first function in the pipe.
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixes

--- a/docs/pipes.md
+++ b/docs/pipes.md
@@ -41,6 +41,31 @@ if_result
 |> IO.inspect()
 ```
 
+### Fold `Kernel` operators at the start of a pipe
+
+When a `Kernel` operator (`++`, `||`, `<>`, `/`, `-`, etc.) is the *first* function in a pipe, Quokka folds it back into an inline expression so it becomes the chain's start rather than an awkward `Kernel.op(...)` call. This is not configurable.
+
+```elixir
+foo
+|> Kernel.||(bar)
+|> Enum.map(&transform/1)
+|> ...
+
+# Styled:
+(foo || bar)
+|> Enum.map(&transform/1)
+|> ...
+```
+
+Only the very first step is folded in this way; a `Kernel` operator later in the chain is left alone.
+
+```elixir
+# Left as-is:
+a
+|> b()
+|> Kernel.++(c)
+```
+
 ### Add parenthesis to function calls in pipes
 
 This addresses [`Credo.Check.Readability.OneArityFunctionInPipe`](https://hexdocs.pm/credo/Credo.Check.Readability.OneArityFunctionInPipe.html). This is not configurable.

--- a/docs/styles.md
+++ b/docs/styles.md
@@ -37,6 +37,26 @@ If you're concerned that this breaks your team's formatting for things like "cen
 | `55333.22 `        | `55_333.22`                                           |
 | `-123456728.0001 ` | `-123_456_728.0001`                                   |
 
+## Fold `Kernel` operators into inline expressions
+
+When a `Kernel` operator (`++`, `||`, `<>`, `/`, `-`, etc.) is called in its fully-qualified function form, Quokka folds it back into the equivalent inline operator expression. This is not configurable.
+
+```elixir
+# Before
+Kernel./(total, size)
+Kernel.++(list, [extra])
+Kernel.-(x)
+
+# Styled
+total / size
+list ++ [extra]
+-x
+```
+
+Operator precedence is preserved (the formatter adds parentheses where needed), so `Kernel.*(Kernel.-(a, b), c)` becomes `(a - b) * c`.
+
+A `Kernel` operator that appears later in a pipe chain (`a |> b() |> Kernel.++(c)`) is left alone, since the pipe supplies its left operand; folding there is handled by the [pipes style](pipes.md#fold-kernel-operators-at-the-start-of-a-pipe) only when the operator starts the chain.
+
 ## Efficient Function Rewrites
 
 All these rewrites are configurable by setting the `exclude: [:inefficient_functions]` option in your `.formatter.exs` file. See the [README](../README.md#configuration) for more information.

--- a/lib/style/pipes.ex
+++ b/lib/style/pipes.ex
@@ -335,7 +335,9 @@ defmodule Quokka.Style.Pipes do
         # we only rewrite unary/infix operators if they're in the Kernel namespace.
         # everything else stays as-is in the `then/2` because we can't know what module they're from
         if fun in @kernel_ops,
-          do: {:|>, m, [lhs, {{:., m2, [{:__aliases__, m2, [:Kernel]}, fun]}, m2, args}]},
+          # recurse so that a `Kernel.op` landing at the start of the pipe gets folded into an
+          # inline expression (e.g. `a |> Kernel.++(b)` => `a ++ b`)
+          do: fix_pipe({:|>, m, [lhs, {{:., m2, [{:__aliases__, m2, [:Kernel]}, fun]}, m2, args}]}),
           else: pipe
 
       true ->
@@ -586,6 +588,32 @@ defmodule Quokka.Style.Pipes do
        when mod in @collectable and enum in @enum do
     {:|>, pm, [lhs, {Style.set_line(new, em[:line]), em, [mapper]}]}
   end
+
+  # When a `Kernel` operator is the first function in a pipe, fold it back into an inline
+  # expression so it serves as the chain's start rather than an awkward `Kernel.op(...)` call:
+  #
+  #     foo
+  #     |> Kernel.||(bar)
+  #     |> Enum.map(...)
+  #
+  # becomes
+  #
+  #     (foo || bar)
+  #     |> Enum.map(...)
+  #
+  # We only fold when the left-hand side isn't itself a pipe (the operator really is the
+  # very first step). Folding a later step (`a |> b() |> Kernel.++(c)`) would change semantics,
+  # since operators like `++` bind tighter than `|>`, so those are left as-is.
+  defp fix_pipe({:|>, _pm, [{:|>, _, _}, {{:., _, [{_, _, [:Kernel]}, op]}, _, _}]} = pipe) when op in @kernel_ops,
+    do: pipe
+
+  # binary op: `lhs |> Kernel.op(rhs)` => `lhs op rhs`
+  defp fix_pipe({:|>, _pm, [{_, lhs_meta, _} = lhs, {{:., _, [{_, _, [:Kernel]}, op]}, _, [rhs]}]})
+       when op in @kernel_ops, do: Style.set_line({op, [line: lhs_meta[:line]], [lhs, rhs]}, lhs_meta[:line])
+
+  # unary op: `lhs |> Kernel.op()` => `op lhs` (e.g. `a |> Kernel.-()` => `-a`)
+  defp fix_pipe({:|>, _pm, [{_, lhs_meta, _} = lhs, {{:., _, [{_, _, [:Kernel]}, op]}, _, []}]}) when op in @kernel_ops,
+    do: Style.set_line({op, [line: lhs_meta[:line]], [lhs]}, lhs_meta[:line])
 
   defp fix_pipe(node), do: node
 

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -33,6 +33,12 @@ defmodule Quokka.Style.SingleNode do
 
   @closing_delimiters [~s|"|, ")", "}", "|", "]", "'", ">", "/"]
 
+  # Kernel infix/unary operators, mirroring `Quokka.Style.Pipes`. `!` and `not` are unary-only;
+  # everything else is a binary operator, with `-` and `+` doubling as unary operators.
+  @kernel_ops ~w(++ -- && || in - * + / > < <= >= == and or != !== === <> ! not)a
+  @kernel_unary_ops ~w(- + ! not)a
+  @kernel_binary_ops @kernel_ops -- ~w(! not)a
+
   # `|> Timex.now()` => `|> Timex.now()`
   # skip over pipes into `Timex.now/1` so that we don't accidentally rewrite it as DateTime.utc_now/1
   def run({{:|>, _, [_, {{:., _, [{:__aliases__, _, [:Timex]}, :now]}, _, []}]}, _} = zipper, ctx),
@@ -67,7 +73,33 @@ defmodule Quokka.Style.SingleNode do
     end
   end
 
+  # Fold a non-piped `Kernel` operator call back into an inline operator expression:
+  #
+  #     Kernel./(total, size)  =>  total / size
+  #     Kernel.-(x)            =>  -x
+  #
+  # Piped `Kernel` ops (`a |> Kernel.++(b)`) are intentionally left alone.
+  def run({{{:., _, [{:__aliases__, _, [:Kernel]}, op]}, meta, args}, _} = zipper, ctx) when op in @kernel_ops do
+    if piped_rhs?(zipper) or not valid_kernel_arity?(op, args) do
+      {:cont, zipper, ctx}
+    else
+      {:cont, Zipper.replace(zipper, {op, [line: meta[:line]], args}), ctx}
+    end
+  end
+
   def run({node, meta}, ctx), do: {:cont, {style(node), meta}, ctx}
+
+  # True when the focused node is the right-hand side of a pipe (`lhs |> focused`).
+  defp piped_rhs?(zipper) do
+    case Zipper.up(zipper) do
+      {{:|>, _, [_lhs, rhs]}, _} -> rhs == Zipper.node(zipper)
+      _ -> false
+    end
+  end
+
+  defp valid_kernel_arity?(op, [_]), do: op in @kernel_unary_ops
+  defp valid_kernel_arity?(op, [_, _]), do: op in @kernel_binary_ops
+  defp valid_kernel_arity?(_op, _args), do: false
 
   # rewrite double-quote strings with >= 4 escaped double-quotes as sigils
   defp style({:__block__, [{:delimiter, ~s|"|} | meta], [string]} = node) when is_binary(string) do

--- a/test/style/pipes_test.exs
+++ b/test/style/pipes_test.exs
@@ -942,7 +942,9 @@ defmodule Quokka.Style.PipesTest do
 
     test "rewrites then/2 when the passed function is a named function reference" do
       assert_style "a |> then(&fun/1) |> c", "a |> fun() |> c()"
-      assert_style "a |> then(&(&1 / 1)) |> c", "a |> Kernel./(1) |> c()"
+      assert_style "a |> foo() |> then(&(&1 / 1)) |> c", "a |> foo() |> Kernel./(1) |> c()"
+      # the extracted kernel op lands at the pipe start, so it's folded inline (then unpiped here)
+      assert_style "a |> then(&(&1 / 1)) |> c", "c(a / 1)"
       assert_style "a |> then(&(&1 * 2 / 1)) |> c()"
       assert_style "a |> then(&fun/1)", "fun(a)"
       assert_style "a |> then(&fun(&1)) |> c", "a |> fun() |> c()"
@@ -953,12 +955,16 @@ defmodule Quokka.Style.PipesTest do
       assert_style "a |> then(&fun(d, &1)) |> c()"
       assert_style "a |> then(&fun(&1, d, %{foo: &1})) |> c()"
 
-      # then + kernel ops
-      assert_style "a |> then(&(-&1)) |> c", "a |> Kernel.-() |> c()"
-      assert_style "a |> then(&(+&1)) |> c", "a |> Kernel.+() |> c()"
+      # then + kernel ops: the extracted op lands at the pipe start and is folded inline
+      # (and then unpiped, since these are single pipes once folded)
+      assert_style "a |> then(&(-&1)) |> c", "c(-a)"
+      assert_style "a |> then(&(+&1)) |> c", "c(+a)"
+      assert_style "a |> foo() |> then(&(-&1)) |> c", "a |> foo() |> Kernel.-() |> c()"
+      assert_style "a |> foo() |> then(&(+&1)) |> c", "a |> foo() |> Kernel.+() |> c()"
 
       for op <- ~w(++ -- && || in - * + / > < <= >= == and or != !== === <>) do
-        assert_style "a |> then(&(&1 #{op} x)) |> c", "a |> Kernel.#{op}(x) |> c()"
+        assert_style "a |> then(&(&1 #{op} x)) |> c", "c(a #{op} x)"
+        assert_style "a |> foo() |> then(&(&1 #{op} x)) |> c", "a |> foo() |> Kernel.#{op}(x) |> c()"
       end
 
       # Doesn't rewrite non-kernel operators
@@ -1042,6 +1048,95 @@ defmodule Quokka.Style.PipesTest do
         |> Enum.sum()
         """
       )
+    end
+
+    test "folds a Kernel op at the start of a pipe into an inline expression" do
+      # single pipe off so the folded expression stays the start of the (still multi-step) pipe
+      stub(Quokka.Config, :single_pipe_flag?, fn -> false end)
+
+      assert_style(
+        """
+        foo
+        |> Kernel.||(bar)
+        |> Enum.map(baz)
+        """,
+        """
+        (foo || bar)
+        |> Enum.map(baz)
+        """
+      )
+
+      assert_style(
+        """
+        inherited_rows
+        |> Kernel.++(account_rows)
+        |> Enum.map(&put_group/1)
+        """,
+        """
+        (inherited_rows ++ account_rows)
+        |> Enum.map(&put_group/1)
+        """
+      )
+
+      assert_style(
+        """
+        (assigns.invoice.amount_due || 0)
+        |> Kernel./(100)
+        |> :erlang.float_to_binary(decimals: 2)
+        """,
+        """
+        ((assigns.invoice.amount_due || 0) / 100)
+        |> :erlang.float_to_binary(decimals: 2)
+        """
+      )
+
+      assert_style(
+        """
+        (contacts || [])
+        |> Kernel.++([contact])
+        |> Enum.uniq_by(& &1.id)
+        """,
+        """
+        ((contacts || []) ++ [contact])
+        |> Enum.uniq_by(& &1.id)
+        """
+      )
+
+      assert_style(
+        """
+        foo
+        |> Kernel.<>("bar")
+        |> String.length()
+        """,
+        """
+        (foo <> "bar")
+        |> String.length()
+        """
+      )
+    end
+
+    test "folds every Kernel binary/unary operator that starts a pipe" do
+      stub(Quokka.Config, :single_pipe_flag?, fn -> false end)
+
+      for op <- ~w(++ -- && || in - * + / > < <= >= == and or != !== === <>) do
+        assert_style("a |> Kernel.#{op}(x) |> c()", "(a #{op} x) |> c()")
+      end
+
+      assert_style("a |> Kernel.-() |> c()", "-a |> c()")
+      assert_style("a |> Kernel.+() |> c()", "+a |> c()")
+    end
+
+    test "only folds a Kernel op when it's the first function in the pipe" do
+      stub(Quokka.Config, :single_pipe_flag?, fn -> false end)
+
+      # later in the chain, the lhs is itself a pipe, so folding would change semantics
+      assert_style("a |> b() |> Kernel.++(c)")
+      assert_style("a |> b() |> Kernel.++(c) |> d()")
+    end
+
+    test "folded single pipe gets unpiped when single pipe rewriting is enabled" do
+      assert_style("a |> Kernel.||(b) |> c()", "c(a || b)")
+      assert_style("a |> Kernel.++(b)", "a ++ b")
     end
 
     test "filter/count" do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -36,6 +36,46 @@ defmodule Quokka.Style.SingleNodeTest do
     assert_style ~s/"\\"\\"\\"\\" \/>']|})"/, ~s|~s("""" />']\|}\\))|
   end
 
+  describe "folds non-piped Kernel operators into inline expressions" do
+    test "binary operator" do
+      assert_style "Kernel./(total, size)", "total / size"
+      assert_style "Kernel.++(a, b)", "a ++ b"
+      assert_style "Kernel.<>(a, b)", "a <> b"
+      assert_style "Kernel.in(a, b)", "a in b"
+      assert_style "Kernel.and(a, b)", "a and b"
+    end
+
+    test "every binary Kernel operator" do
+      for op <- ~w(++ -- && || in - * + / > < <= >= == and or != !== === <>) do
+        assert_style "Kernel.#{op}(a, b)", "a #{op} b"
+      end
+    end
+
+    test "unary operator" do
+      assert_style "Kernel.-(x)", "-x"
+      assert_style "Kernel.+(x)", "+x"
+      assert_style "Kernel.!(x)", "!x"
+      assert_style "Kernel.not(x)", "not x"
+    end
+
+    test "folds when nested in other expressions" do
+      assert_style "foo(Kernel./(a, b))", "foo(a / b)"
+      assert_style "x = Kernel.*(a, b)", "x = a * b"
+      assert_style "Kernel./(a, b) + c", "a / b + c"
+    end
+
+    test "preserves operator precedence with parens" do
+      # `*` binds tighter than `+`, so the folded subtraction needs parens to keep its meaning
+      assert_style "Kernel.*(Kernel.-(a, b), c)", "(a - b) * c"
+    end
+
+    test "leaves a piped Kernel operator alone (the Pipes style owns those)" do
+      # later in a chain the operand count differs and folding would change semantics
+      assert_style "a |> b() |> Kernel.++(c)"
+      assert_style "a |> b() |> Kernel.-(c)"
+    end
+  end
+
   describe "{Keyword/Map}.merge/2 of a single key => *.put/3" do
     test "in a pipe" do
       for module <- ~w(Map Keyword) do


### PR DESCRIPTION
This is a readability improvement for Kernel operators called in two places:
1. At the start of pipe chains
2. In a standalone context (outside of any pipes)

If it's possible to replace piping into a Kernel expression without drastically restructuring the surrounding code, it's desirable to do so (in my opinion, at least).

Rewrites things like:

```elixir
foo
|> Kernel.||(bar)
|> Enum.map(baz)
|> ...
```

to:

```elixir
(foo || bar)
|> Enum.map(baz)
|> ...
```

Or:
```elixir
Kernel./(total, size) -> total / size
foo(Kernel./(a, b)) -> foo(a / b)
Kernel.*(Kernel.-(a, b), c) -> (a - b) * c
```

## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes

Note that CI is failing pending #168