### PR TITLE
feat: Combine or-chains of String.starts_with?/2, ends_with?/2, and contains?/2

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -78,6 +78,43 @@ if foo |> MyModule.transform() |> Enum.count(enum) > 0, do: "not empty"
 if foo |> MyModule.transform() |> Enum.count(enum) > 0, do: "not empty"
 ```
 
+### Or-chains of `String.starts_with?`/`String.ends_with?`/`String.contains?` -> list form
+
+`String.starts_with?/2`, `String.ends_with?/2`, and `String.contains?/2` all accept a list of
+patterns as their second argument, returning `true` if any of them match. When multiple checks
+against the *same* subject are combined with `or`/`||`, Quokka collapses them into a single call with a
+list. When the input string is large, this is a significant performance improvement for `String.contains/2`
+because internally, it will use `:binary.match/2` to only scan the input string once. In the other cases,
+it's more or less a wash—just a nice readability improvement.
+
+Only literal patterns (a string or a list of strings) are combined. If any pattern is a variable,
+Quokka leaves the chain alone, since the variable could be either a string or a list.
+
+```elixir
+# Before
+String.starts_with?(foo, "bar") or String.starts_with?(foo, "baz")
+# Styled
+String.starts_with?(foo, ["bar", "baz"])
+
+# Before (lists and strings mix freely)
+String.starts_with?(foo, ["bar", "baz"]) || String.starts_with?(foo, "bop")
+# Styled
+String.starts_with?(foo, ["bar", "baz", "bop"])
+
+# Before
+String.ends_with?(foo, ["bar", "baz"]) or String.ends_with?(foo, ["bop", "whiz"])
+# Styled
+String.ends_with?(foo, ["bar", "baz", "bop", "whiz"])
+
+# Before
+String.contains?(foo, "bar") || String.contains?(foo, "baz")
+# Styled
+String.contains?(foo, ["bar", "baz"])
+
+# Left unchanged: the sought value is a variable, so it might be a string or a list
+String.ends_with?(foo, bar) or String.ends_with?(foo, baz)
+```
+
 ### `Enum.into` -> `X.new`
 
 This rewrite is applied when the collectable is a new map, keyword list, or mapset via `Enum.into/2,3`.

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -29,6 +29,7 @@ defmodule Quokka.Style.SingleNode do
 
   @behaviour Quokka.Style
 
+  alias Quokka.Style
   alias Quokka.Zipper
 
   @closing_delimiters [~s|"|, ")", "}", "|", "]", "'", ">", "/"]
@@ -587,7 +588,73 @@ defmodule Quokka.Style.SingleNode do
     end
   end
 
+  # `String.starts_with?(s, "a") or String.starts_with?(s, "b")` => `String.starts_with?(s, ["a", "b"])`
+  # Same for `String.ends_with?/2` and `String.contains?/2`, and for `||` chains. All three accept a
+  # list of patterns, so collapsing an `or`-chain of checks against the same subject into a single
+  # call is more efficient and more readable. Only literal search arguments are combined; a variable
+  # might be a string or a list, so we leave it.
+  defp style({op, _, [_, _]} = node) when op in [:or, :||] do
+    if Quokka.Config.inefficient_function_rewrites?(),
+      do: merge_string_affix_checks(node),
+      else: node
+  end
+
   defp style(node), do: node
+
+  defp merge_string_affix_checks({op, m, _} = node) when op in [:or, :||] do
+    operands = flatten_or(node)
+
+    merged =
+      operands
+      |> Enum.reduce([], fn operand, acc ->
+        with [prev | rest] <- acc,
+             {fun, subject, searches} <- string_affix_check(operand),
+             {^fun, prev_subject, prev_searches} <- string_affix_check(prev),
+             true <- Style.without_meta(subject) == Style.without_meta(prev_subject) do
+          [combine_affix_check(prev, prev_searches ++ searches) | rest]
+        else
+          _ -> [operand | acc]
+        end
+      end)
+      |> Enum.reverse()
+
+    if length(merged) == length(operands) do
+      node
+    else
+      [first | rest] = merged
+      Enum.reduce(rest, first, fn operand, acc -> {op, m, [acc, operand]} end)
+    end
+  end
+
+  defp flatten_or({op, _, [lhs, rhs]}) when op in [:or, :||], do: flatten_or(lhs) ++ flatten_or(rhs)
+  defp flatten_or(node), do: [node]
+
+  # Returns `{fun, subject, search_nodes}` for a `String.starts_with?/2`, `String.ends_with?/2`, or
+  # `String.contains?/2` call whose second argument is a string literal or a list of string
+  # literals; `nil` otherwise.
+  defp string_affix_check({{:., _, [{:__aliases__, _, [:String]}, fun]}, _, [subject, sought]})
+       when fun in [:starts_with?, :ends_with?, :contains?] do
+    case literal_searches(sought) do
+      nil -> nil
+      searches -> {fun, subject, searches}
+    end
+  end
+
+  defp string_affix_check(_), do: nil
+
+  defp literal_searches({:__block__, _, [string]} = node) when is_binary(string), do: [node]
+
+  defp literal_searches({:__block__, _, [list]}) when is_list(list) do
+    if Enum.all?(list, &match?({:__block__, _, [s]} when is_binary(s), &1)), do: list
+  end
+
+  defp literal_searches(_), do: nil
+
+  # Rebuilds an affix-check call, reusing the original call's AST and replacing only its
+  # second argument with the combined list of search literals.
+  defp combine_affix_check({fun_dot, m, [subject, _sought]}, searches) do
+    {fun_dot, m, [subject, {:__block__, m, [searches]}]}
+  end
 
   # True when the name is something like :"&1" or :"&2"
   defp anonymous_arg?(name) when is_atom(name) do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -1493,4 +1493,106 @@ defmodule Quokka.Style.SingleNodeTest do
       assert_style("enum |> Enum.reduce(0, &+/2)", "enum |> Enum.sum()")
     end
   end
+
+  describe "String.starts_with?/ends_with?/contains? or-chains => list form" do
+    test "combines two single-string checks" do
+      for function <- [:starts_with?, :ends_with?, :contains?] do
+        assert_style(
+          ~s|String.#{function}(foo, "bar") or String.#{function}(foo, "baz")|,
+          ~s|String.#{function}(foo, ["bar", "baz"])|
+        )
+
+        assert_style(
+          ~s'String.#{function}(foo, "bar") || String.#{function}(foo, "baz")',
+          ~s|String.#{function}(foo, ["bar", "baz"])|
+        )
+      end
+    end
+
+    test "combines a list and a single string" do
+      for function <- [:starts_with?, :ends_with?, :contains?] do
+        assert_style(
+          ~s|String.#{function}(foo, ["bar", "baz"]) or String.#{function}(foo, "bop")|,
+          ~s|String.#{function}(foo, ["bar", "baz", "bop"])|
+        )
+      end
+    end
+
+    test "combines a single string and a list" do
+      assert_style(
+        ~s|String.starts_with?(foo, "bar") or String.starts_with?(foo, ["baz", "bop"])|,
+        ~s|String.starts_with?(foo, ["bar", "baz", "bop"])|
+      )
+    end
+
+    test "combines two lists" do
+      assert_style(
+        ~s|String.ends_with?(foo, ["bar", "baz"]) or String.ends_with?(foo, ["bop", "whiz"])|,
+        ~s|String.ends_with?(foo, ["bar", "baz", "bop", "whiz"])|
+      )
+    end
+
+    test "combines a chain of three or more" do
+      assert_style(
+        ~s'String.starts_with?(foo, "a") or String.starts_with?(foo, "b") || String.starts_with?(foo, "c")',
+        ~s|String.starts_with?(foo, ["a", "b", "c"])|
+      )
+
+      combiners =
+        Stream.repeatedly(fn -> Enum.random([:or, :||]) end)
+        |> Stream.take(4)
+
+      a_through_d =
+        combiners
+        |> Enum.zip(["a", "b", ["c"], "d"])
+        |> Enum.map(fn {combiner, arg} -> ~s'String.starts_with?(foo, #{inspect(arg)}) #{combiner} ' end)
+
+      assert_style(
+        ~s'#{a_through_d} String.starts_with?(foo, "e") ',
+        ~s|String.starts_with?(foo, ["a", "b", "c", "d", "e"])|
+      )
+    end
+
+    test "works with a non-variable subject" do
+      assert_style(
+        ~s|String.starts_with?(get_str(), "bar") or String.starts_with?(get_str(), "baz")|,
+        ~s|String.starts_with?(get_str(), ["bar", "baz"])|
+      )
+    end
+
+    test "does not touch chains with a non-literal sought argument" do
+      assert_style(~s|String.ends_with?(foo, bar) or String.ends_with?(foo, baz)|)
+      assert_style(~s'String.starts_with?(foo, "bar") || String.starts_with?(foo, baz)')
+      assert_style(~s|String.contains?(foo, [bar, "baz"]) or String.contains?(foo, "bop")|)
+    end
+
+    test "does not combine mismatched functions" do
+      assert_style(~s|String.starts_with?(foo, "bar") or String.ends_with?(foo, "baz")|)
+      assert_style(~s|String.contains?(foo, "bar") or String.starts_with?(foo, "baz")|)
+      assert_style(~s'String.contains?(foo, "bar") || String.ends_with?(foo, "baz")')
+    end
+
+    test "does not combine mismatched subjects" do
+      assert_style(~s|String.starts_with?(foo, "bar") or String.starts_with?(bar, "baz")|)
+    end
+
+    test "only combines adjacent matches in a mixed chain" do
+      assert_style(
+        ~s|String.starts_with?(foo, "a") or flag or String.starts_with?(foo, "b") or String.starts_with?(foo, "c")|,
+        ~s|String.starts_with?(foo, "a") or flag or String.starts_with?(foo, ["b", "c"])|
+      )
+    end
+
+    test "respects inefficient_functions config" do
+      stub(Quokka.Config, :inefficient_function_rewrites?, fn -> false end)
+      assert_style(~s|String.starts_with?(foo, "bar") or String.starts_with?(foo, "baz")|)
+
+      stub(Quokka.Config, :inefficient_function_rewrites?, fn -> true end)
+
+      assert_style(
+        ~s|String.starts_with?(foo, "bar") or String.starts_with?(foo, "baz")|,
+        ~s|String.starts_with?(foo, ["bar", "baz"])|
+      )
+    end
+  end
 end


### PR DESCRIPTION
This adds a new rewrite for chains of string content checks. Rather than making multiple calls to these functions like:

```elixir
String.starts_with?(foo, "bar") or String.starts_with?(foo, "baz")
```

...we can improve the readability by combining these into a single call to the function with a list of search candidates:

```elixir
String.starts_with?(foo, ["bar", "baz"])
```

When the input string is large, this is a clear performance improvement for `String.contains/2` because internally, it will use `:binary.match/2` to only scan the input string once. In the other cases, it's more or less a wash—just a nice readability improvement.

## PR Checklist


- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [N/A] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
