### PR TITLE
feat (blocks): Rewrite `case` that matches on true/false to use `if` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+- Added rewrite for `case` expressions that can be rewritten as `if`.
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixes

--- a/docs/control_flow_macros.md
+++ b/docs/control_flow_macros.md
@@ -90,6 +90,69 @@ else
 end
 ```
 
+## `case`
+
+Quokka rewrites trivial two-clause `case` expressions to `if` expressions. This applies when the first clause matches `true` and the second matches `false` or a catch-all (`_`).
+
+```elixir
+case foo do
+  true -> b
+  false -> c
+end
+# Styled:
+if foo do
+  b
+else
+  c
+end
+```
+
+```elixir
+case foo?(bar) do
+  true -> b
+  _ -> c
+end
+# Styled:
+if foo?(bar) do
+  b
+else
+  c
+end
+```
+
+This also applies when piping into `case`. A single pipe is folded into a function call; longer chains stay piped.
+
+```elixir
+foo
+|> bar?()
+|> case do
+  true -> b
+  false -> c
+end
+# Styled:
+if bar?(foo) do
+  b
+else
+  c
+end
+```
+
+```elixir
+foo
+|> bar()
+|> baz?()
+|> case do
+  true -> b
+  _ -> c
+end
+# Styled:
+if foo |> bar() |> baz?() do
+  b
+else
+  c
+end
+```
+
 ## `with`
 
 This addresses [`Credo.Check.Readability.WithSingleClause`](https://hexdocs.pm/credo/Credo.Check.Readability.WithSingleClause.html), [`Credo.Check.Refactor.RedundantWithClauseResult`](https://hexdocs.pm/credo/Credo.Check.Refactor.RedundantWithClauseResult.html), and [`Credo.Check.Refactor.WithClauses`](https://hexdocs.pm/credo/Credo.Check.Refactor.WithClauses.html). This is not configurable.

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -44,7 +44,6 @@ defmodule Quokka.Config do
 
   # CommentDirectives is not configurable; # quokka:sort always runs.
   @style_pipeline [
-    Blocks,
     CommentDirectives,
     Autosort,
     Configs,
@@ -53,6 +52,7 @@ defmodule Quokka.Config do
     ModuleDirectives,
     Pipes,
     SingleNode,
+    Blocks,
     Tests
   ]
 

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -34,12 +34,9 @@ defmodule Quokka.Style.Blocks do
 
   # Pipe-into-case to if: `foo |> bar() |> case do true -> a; false -> b end`
   def run({{:|>, _, [pipe_chain, {:case, _, [[{{:__block__, _, [:do]}, clauses}]]}]}, _} = zipper, ctx) do
-    case trivial_case_to_if(clauses) do
-      {:ok, {do_body, else_body}} ->
-        case_to_if_ast(zipper, case_subject(pipe_chain), do_body, else_body, ctx)
-
-      :error ->
-        {:cont, zipper, ctx}
+    case not piping_case_into_case?(pipe_chain) and trivial_case_to_if(clauses) do
+      {:ok, {do_body, else_body}} -> case_to_if_ast(zipper, case_subject(pipe_chain), do_body, else_body, ctx)
+      _ -> {:cont, zipper, ctx}
     end
   end
 
@@ -452,6 +449,10 @@ defmodule Quokka.Style.Blocks do
   defp catch_all_clause_pattern?(false), do: true
   defp catch_all_clause_pattern?({:_, _, nil}), do: true
   defp catch_all_clause_pattern?(_), do: false
+
+  defp piping_case_into_case?({:case, _, _}), do: true
+  defp piping_case_into_case?({:|>, _, [lhs, rhs]}), do: piping_case_into_case?(lhs) or piping_case_into_case?(rhs)
+  defp piping_case_into_case?(_), do: false
 
   # `foo |> bar?() |> case` becomes `if bar?(foo)`, but longer chains stay piped:
   # `foo |> bar() |> baz?() |> case` becomes `if foo |> bar() |> baz?()`

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -32,13 +32,47 @@ defmodule Quokka.Style.Blocks do
   defguardp is_negator(n) when elem(n, 0) in [:!, :not, :!=, :!==]
   defguardp is_empty_body(n) when elem(n, 0) == :__block__ and elem(n, 2) in [[nil], []]
 
-  # Pipe into case: case foo |> bar() do ... end => foo |> bar() |> case do ... end
-  def run({{:case, case_meta, [{:|>, _, _} = pipe_chain, clauses]}, _} = zipper, ctx) do
-    if Quokka.Config.pipe_into_case?() do
-      new_node = {:|>, [line: case_meta[:line]], [pipe_chain, {:case, case_meta, [clauses]}]}
-      {:cont, Zipper.replace(zipper, new_node), ctx}
-    else
-      {:cont, zipper, ctx}
+  # Pipe-into-case to if: `foo |> bar() |> case do true -> a; false -> b end`
+  def run({{:|>, _, [pipe_chain, {:case, _, [[{{:__block__, _, [:do]}, clauses}]]}]}, _} = zipper, ctx) do
+    case trivial_case_to_if(clauses) do
+      {:ok, {do_body, else_body}} ->
+        case_to_if_ast(zipper, case_subject(pipe_chain), do_body, else_body, ctx)
+
+      :error ->
+        {:cont, zipper, ctx}
+    end
+  end
+
+  # Handles both:
+  # - Pipe into case: case foo |> bar() do ... end => foo |> bar() |> case do ... end
+  # - Case to if: case expr do true -> a; false -> b end => if expr do a else b end
+  def run({{:case, case_meta, args}, _} = zipper, ctx) do
+    case args do
+      [{:|>, _, _} = pipe_chain, [{{:__block__, _, [:do]}, clauses}] = do_and_clauses] ->
+        case trivial_case_to_if(clauses) do
+          {:ok, {do_body, else_body}} ->
+            case_to_if_ast(zipper, case_subject(pipe_chain), do_body, else_body, ctx)
+
+          :error ->
+            if Quokka.Config.pipe_into_case?() do
+              new_node = {:|>, [line: case_meta[:line]], [pipe_chain, {:case, case_meta, [do_and_clauses]}]}
+              {:cont, Zipper.replace(zipper, new_node), ctx}
+            else
+              {:cont, zipper, ctx}
+            end
+        end
+
+      [subject, [{{:__block__, _, [:do]}, clauses}]] ->
+        case trivial_case_to_if(clauses) do
+          {:ok, {do_body, else_body}} ->
+            case_to_if_ast(zipper, case_subject(subject), do_body, else_body, ctx)
+
+          :error ->
+            {:cont, zipper, ctx}
+        end
+
+      _ ->
+        {:cont, zipper, ctx}
     end
   end
 
@@ -388,4 +422,60 @@ defmodule Quokka.Style.Blocks do
   defp invert({:not, _, [condition]}), do: condition
   defp invert({:in, m, [_, _]} = ast), do: {:not, m, [ast]}
   defp invert({_, m, _} = ast), do: {:!, [line: m[:line]], [ast]}
+
+  defp trivial_case_to_if([{:->, _, [[true_pattern], do_body]}, {:->, _, [[else_pattern], else_body]}]) do
+    if true_clause_pattern?(true_pattern) and catch_all_clause_pattern?(else_pattern) do
+      {:ok, {do_body, else_body}}
+    else
+      :error
+    end
+  end
+
+  defp trivial_case_to_if(_), do: :error
+
+  defp case_to_if_ast(zipper, head, do_body, else_body, ctx) do
+    {head, do_body, else_body} =
+      if is_negator(head) and Config.negated_conditions_with_else?() do
+        {invert(head), else_body, do_body}
+      else
+        {head, do_body, else_body}
+      end
+
+    if_ast(zipper, head, do_body, else_body, ctx)
+  end
+
+  defp true_clause_pattern?({:__block__, _, [true]}), do: true
+  defp true_clause_pattern?(true) when true == true, do: true
+  defp true_clause_pattern?(_), do: false
+
+  defp catch_all_clause_pattern?({:__block__, _, [false]}), do: true
+  defp catch_all_clause_pattern?(false), do: true
+  defp catch_all_clause_pattern?({:_, _, nil}), do: true
+  defp catch_all_clause_pattern?(_), do: false
+
+  # `foo |> bar?() |> case` becomes `if bar?(foo)`, but longer chains stay piped:
+  # `foo |> bar() |> baz?() |> case` becomes `if foo |> bar() |> baz?()`
+  defp case_subject({:|>, _, [lhs, _rhs]} = pipe_chain) do
+    if match?({:|>, _, _}, lhs), do: inline_pipe_chain(pipe_chain), else: fold_pipe_to_call(pipe_chain)
+  end
+
+  defp case_subject(other), do: other
+
+  defp inline_pipe_chain(pipe_chain) do
+    line = pipe_chain_start_line(pipe_chain)
+
+    pipe_chain
+    |> Style.set_line(line)
+    |> Style.update_all_meta(&Keyword.delete(&1, :end_of_expression))
+  end
+
+  defp pipe_chain_start_line({:|>, _, [lhs, _]}), do: pipe_chain_start_line(lhs)
+  defp pipe_chain_start_line({_, meta, _}), do: meta[:line]
+
+  defp fold_pipe_to_call({:|>, _, [lhs, rhs]}), do: prepend_pipe_arg(fold_pipe_to_call(lhs), rhs)
+  defp fold_pipe_to_call(other), do: other
+
+  defp prepend_pipe_arg(lhs, {fun, meta, args}) when is_atom(fun), do: {fun, meta, [lhs | args || []]}
+
+  defp prepend_pipe_arg(lhs, {{:., m, [mod, fun]}, meta, args}), do: {{:., m, [mod, fun]}, meta, [lhs | args || []]}
 end

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -660,6 +660,101 @@ defmodule Quokka.Style.BlocksTest do
     end
   end
 
+  describe "case statements that can be rewritten as `if`" do
+    test "replaces explicit true/false" do
+      assert_style(
+        """
+        case foo do
+          true -> b
+          false -> c
+        end
+        """,
+        """
+        if foo do
+          b
+        else
+          c
+        end
+        """
+      )
+    end
+
+    test "replaces when only true is specified" do
+      assert_style(
+        """
+        case foo do
+          true -> b
+          _ -> c
+        end
+        """,
+        """
+        if foo do
+          b
+        else
+          c
+        end
+        """
+      )
+    end
+
+    test "replaces when there's a function call involved" do
+      assert_style(
+        """
+        case foo?(bar) do
+          true -> b
+          _ -> c
+        end
+        """,
+        """
+        if foo?(bar) do
+          b
+        else
+          c
+        end
+        """
+      )
+    end
+
+    test "replaces when piping into case" do
+      assert_style(
+        """
+        foo
+        |> bar?()
+        |> case do
+          true -> b
+          false -> c
+        end
+        """,
+        """
+        if bar?(foo) do
+          b
+        else
+          c
+        end
+        """
+      )
+
+      assert_style(
+        """
+        foo
+        |> bar()
+        |> baz?()
+        |> case do
+          true -> b
+          false -> c
+        end
+        """,
+        """
+        if foo |> bar() |> baz?() do
+          b
+        else
+          c
+        end
+        """
+      )
+    end
+  end
+
   describe "pipe into case" do
     test "transforms case with pipe chain subject to pipe into case" do
       assert_style(

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -753,6 +753,32 @@ defmodule Quokka.Style.BlocksTest do
         """
       )
     end
+
+    test "does not attempt to rewrite piping case into case because the results are horrifyingly inelegant" do
+      assert_style("""
+      case val do
+        x when x > 10 -> true
+        _ -> false
+      end
+      |> case do
+        true -> :ok
+        false -> :error
+      end
+      """)
+
+      assert_style("""
+      from(cb in CallBot, where: cb.ext_bot_id == ^id)
+      |> Repo.one()
+      |> case do
+        %{val: x} when x > 10 -> true
+        _ -> false
+      end
+      |> case do
+        true -> :ok
+        false -> :error
+      end
+      """)
+    end
   end
 
   describe "pipe into case" do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -383,10 +383,14 @@ defmodule Quokka.Style.SingleNodeTest do
           false -> :empty
         end
         """,
+        # We would have to run `Blocks` twice in the `@style_pipeline` of `Quokka.Config`
+        # get the rewrite that swaps the true/false clauses. While we *could* do that,
+        # it's probably not worth the performance hit.
         """
-        case not Enum.empty?(items) do
-          true -> :has_items
-          false -> :empty
+        if not Enum.empty?(items) do
+          :has_items
+        else
+          :empty
         end
         """
       )

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -383,14 +383,11 @@ defmodule Quokka.Style.SingleNodeTest do
           false -> :empty
         end
         """,
-        # We would have to run `Blocks` twice in the `@style_pipeline` of `Quokka.Config`
-        # get the rewrite that swaps the true/false clauses. While we *could* do that,
-        # it's probably not worth the performance hit.
         """
-        if not Enum.empty?(items) do
-          :has_items
-        else
+        if Enum.empty?(items) do
           :empty
+        else
+          :has_items
         end
         """
       )


### PR DESCRIPTION
This adds a new rewrite to take `case` expression that just match on true/false (or true/other) and rewrite them to an `if` expression instead.

## PR Checklist


- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [N/A] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
