### PR TITLE
Support glob patterns in `files.included`/`files.excluded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Quokka follows [Semantic Versioning](https://semver.org) and
 
 ## [Unreleased]
 
+### Fixes
+
+- Support glob patterns in `files.included`/`files.excluded` (e.g. `"config/*.exs"`), like `:inputs`. Fixes [#174](https://github.com/emkguts/quokka/issues/174).
+
 ## [2.13.1] - 2026-05-19
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ in `.formatter.exs` to fine tune your setup:
   quokka: [
     autosort: [:map, :defstruct, :schema],
     files: %{
-      included: ["lib/", ...],
-      excluded: ["lib/example.ex", ...]
+      included: ["lib/", "test/**/*.exs"],
+      excluded: ["lib/example.ex", "config/*.exs"]
     },
     only: [
       # Config-driven autosort for maps, defstructs, and schemas
@@ -121,7 +121,7 @@ in `.formatter.exs` to fine tune your setup:
 | `:autosort` | Config-driven sorting for maps, defstructs, and/or schemas. Separate from `# quokka:sort`, which always runs. See [Autosort](docs/autosort.md) and [Comment Directives](docs/comment_directives.md). | `:map, :defstruct, :schema` | `[]` |
 | `autosort: [schema: [:field, :has_many, ...]]` | Custom type ordering for schemas | All Ecto schema types | `[:field, :belongs_to, :has_many, :has_one, :many_to_many, :embeds_many, :embeds_one]` |
 | `exclude: [:autosort]` | Disables config-driven autosort (`# quokka:sort` still runs) | | |
-| `:files` | Quokka gets files from `.formatter.exs[:inputs]`. However, in some cases you may need to selectively exclude/include files you wish to still run in `mix format`, but have different behavior with Quokka. | `%{included: [], excluded: []}` (all files included, none excluded) | `%{included: [], excluded: []}` |
+| `:files` | Quokka gets files from `.formatter.exs[:inputs]`. However, in some cases you may need to selectively exclude/include files you wish to still run in `mix format`, but have different behavior with Quokka. Entries may be directory prefixes or glob patterns. | `%{included: [], excluded: []}` (all files included, none excluded) | `%{included: [], excluded: []}` |
 | `:only` | Only include the given modules. `# quokka:sort` always runs. The special `:line_length` option excludes all other changes except line length fixups. | `[:autosort, :blocks, :configs, :defs, :deprecations, :line_length, :module_directives, :pipes, :single_node, :tests]` | `[]` (all modules included) |
 | `:exclude` | Rewrites to exclude. This filters from the `:only` list, and includes additional exclusion options (`:nums_with_underscores, :autosort_ecto, :inefficient_functions, :piped_functions, :pipe_into_case`). `# quokka:sort` cannot be disabled. | `[:autosort, :blocks, :configs, :defs, :deprecations, :line_length, :module_directives, :pipes, :single_node, :tests, :nums_with_underscores, :autosort_ecto, :inefficient_functions, :piped_functions, :pipe_into_case]` | `[]` (all rewrites included) |
 | `exclude: [:inefficient_functions]` | Excludes rewriting inefficient functions to more efficient form |  |  |

--- a/lib/quokka/config.ex
+++ b/lib/quokka/config.ex
@@ -177,12 +177,35 @@ defmodule Quokka.Config do
     relative_path = Path.relative_to_cwd(file)
     included_dirs = get(:directories_included)
     excluded_dirs = get(:directories_excluded)
+    included_globs = get(:files_included)
+    excluded_globs = get(:files_excluded)
 
     cond do
-      Enum.any?(excluded_dirs, &String.starts_with?(relative_path, &1)) -> false
+      matches_files?(relative_path, excluded_dirs, excluded_globs) -> false
       Enum.empty?(included_dirs) -> true
-      true -> Enum.any?(included_dirs, &String.starts_with?(relative_path, &1))
+      true -> matches_files?(relative_path, included_dirs, included_globs)
     end
+  end
+
+  # A path matches when it is prefixed by one of the configured entries (the
+  # historical `String.starts_with?/2` behaviour, kept for bare directory
+  # prefixes like `"config/"`) or when it is among the files expanded from a
+  # glob pattern (e.g. `"config/*.exs"`), mirroring how `mix format` resolves
+  # `:inputs`/`:excludes` via `Path.wildcard/2`.
+  defp matches_files?(relative_path, prefixes, globbed_files) do
+    Enum.any?(prefixes, &String.starts_with?(relative_path, &1)) or
+      MapSet.member?(globbed_files, relative_path)
+  end
+
+  # Expand the configured `:included`/`:excluded` entries into the concrete set
+  # of cwd-relative files they match, the same way `mix format` expands its
+  # `:inputs`/`:excludes`. Bare directory prefixes (e.g. `"config/"`) expand to
+  # nothing here and are handled by the prefix check in `matches_files?/3`.
+  defp expand_file_globs(patterns) do
+    patterns
+    |> List.wrap()
+    |> Enum.flat_map(&Path.wildcard(Path.expand(&1, File.cwd!()), match_dot: true))
+    |> MapSet.new(&Path.relative_to_cwd/1)
   end
 
   defp build_config_map(formatter_opts, quokka, credo, exclude, plugins, plugin_opts) do
@@ -201,6 +224,8 @@ defmodule Quokka.Config do
       elixir_version: parse_elixir_version(),
       exclude_nums_with_underscores: :nums_with_underscores in exclude,
       exclude_styles: exclude,
+      files_excluded: expand_file_globs(Map.get(quokka[:files] || %{}, :excluded, [])),
+      files_included: expand_file_globs(Map.get(quokka[:files] || %{}, :included, [])),
       inefficient_function_rewrites: inefficient_function_rewrites,
       only_styles: quokka[:only] || [],
       pipe_into_case: :pipe_into_case not in exclude,

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -170,4 +170,48 @@ defmodule Quokka.ConfigTest do
     assert :ok = Quokka.Config.set!([])
     assert System.version() == Quokka.Config.elixir_version()
   end
+
+  describe "allowed_directory?/1 with `:files`" do
+    test "excludes via a bare directory prefix (legacy behaviour)" do
+      assert :ok = set!(quokka: [files: %{excluded: ["lib/quokka/"]}])
+
+      refute Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+      assert Quokka.Config.allowed_directory?("lib/styler.ex")
+    end
+
+    test "excludes via a single-segment glob pattern" do
+      assert :ok = set!(quokka: [files: %{excluded: ["lib/quokka/*.ex"]}])
+
+      refute Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+      # `*` does not cross directory boundaries
+      assert Quokka.Config.allowed_directory?("lib/quokka/config/credo.ex")
+    end
+
+    test "excludes via a recursive `**` glob pattern" do
+      assert :ok = set!(quokka: [files: %{excluded: ["lib/**/*.ex"]}])
+
+      refute Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+      refute Quokka.Config.allowed_directory?("lib/quokka/config/credo.ex")
+    end
+
+    test "includes only files matching a glob pattern" do
+      assert :ok = set!(quokka: [files: %{included: ["lib/quokka/*.ex"]}])
+
+      assert Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+      refute Quokka.Config.allowed_directory?("lib/styler.ex")
+    end
+
+    test "exclusion wins over inclusion" do
+      assert :ok = set!(quokka: [files: %{included: ["lib/**/*.ex"], excluded: ["lib/quokka/*.ex"]}])
+
+      refute Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+      assert Quokka.Config.allowed_directory?("lib/styler.ex")
+    end
+
+    test "empty `:files` allows everything" do
+      assert :ok = set!([])
+
+      assert Quokka.Config.allowed_directory?("lib/quokka/config.ex")
+    end
+  end
 end


### PR DESCRIPTION
## Description

`quokka.files.excluded`/`included` only matched via `String.starts_with?` on the relative path, so glob patterns such as `"config/*.exs"` silently matched nothing while looking like the globs used by `mix format`'s `:inputs`. Users had to discover that only bare directory prefixes work.

Expand each entry with `Path.wildcard/2` (mirroring how `mix format` resolves `:inputs`/`:excludes`) into a cwd-relative MapSet, and match a file if it is either prefixed by an entry (legacy behaviour, kept for bare dir prefixes like `"config/"`) or a member of the expanded set. Fully backward compatible.

resolves #174

_Authored with assistance from Claude Code._


## PR Checklist

<!--
You don't actually need to include this section in your PR, but following this list
helps us a ton, especially reminders for updating docs so we don't have to change
them ourselves before releases ❤️
-->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] If there are changes to installation, usage, or project overview, I have updated README.md
- [x] If there are changes to styling, I have updated the relevant `/docs/*.md` file
- [x] I have run `mix format` and committed any changes
